### PR TITLE
チャット画面リロード時にもチャットルームを取得する

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -3,7 +3,6 @@ import {
   SubscribeMessage,
   WebSocketGateway,
   WebSocketServer,
-  OnGatewayConnection,
   ConnectedSocket,
 } from '@nestjs/websockets';
 import { Server, Socket } from 'socket.io';
@@ -18,7 +17,7 @@ import { ChatRoom as ChatRoomModel } from '@prisma/client';
   },
   namespace: '/chat',
 })
-export class ChatGateway implements OnGatewayConnection {
+export class ChatGateway {
   constructor(
     private prisma: PrismaService,
     private readonly chatService: ChatService,
@@ -28,19 +27,25 @@ export class ChatGateway implements OnGatewayConnection {
 
   private logger: Logger = new Logger('ChatGateway');
 
-  // 新しいクライアントが接続してきたときの処理
-  async handleConnection(@ConnectedSocket() client: Socket) {
-    this.logger.log(`Client connected: ${client.id}`);
-    const data = await this.chatService.chatRooms({});
-    this.server.emit('chat:connected', data);
-  }
-
+  /**
+   * チャットルームを作成する
+   */
   @SubscribeMessage('room:create')
   CreateRoom(@MessageBody() data: ChatRoomModel): void {
-    this.logger.log(`[DEBUG] room:create': ${data.name}`);
+    this.logger.log(`room:create': ${data.name}`);
     // とりあえずvoidで受ける
     void this.chatService.createChatRoom(data);
     // 送信者にdataを送り返す
-    this.server.emit('room:created', data);
+    this.server.emit('room:create', data);
+  }
+
+  /**
+   * チャットルーム一覧を返す
+   */
+  @SubscribeMessage('room:getRooms')
+  async GetRooms(@ConnectedSocket() client: Socket) {
+    this.logger.log(`room:getRooms: ${client.id}`);
+    const data = await this.chatService.chatRooms({});
+    this.server.emit('chat:getRooms', data);
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -30,21 +30,21 @@ export class ChatGateway {
   /**
    * チャットルームを作成する
    */
-  @SubscribeMessage('room:create')
+  @SubscribeMessage('chat:create')
   CreateRoom(@MessageBody() data: ChatRoomModel): void {
-    this.logger.log(`room:create': ${data.name}`);
+    this.logger.log(`chat:create': ${data.name}`);
     // とりあえずvoidで受ける
     void this.chatService.createChatRoom(data);
     // 送信者にdataを送り返す
-    this.server.emit('room:create', data);
+    this.server.emit('chat:create', data);
   }
 
   /**
    * チャットルーム一覧を返す
    */
-  @SubscribeMessage('room:getRooms')
+  @SubscribeMessage('chat:getRooms')
   async GetRooms(@ConnectedSocket() client: Socket) {
-    this.logger.log(`room:getRooms: ${client.id}`);
+    this.logger.log(`chat:getRooms: ${client.id}`);
     const data = await this.chatService.chatRooms({});
     this.server.emit('chat:getRooms', data);
   }

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -28,8 +28,8 @@ const createChatRoom = () => {
     author: 'admin',
     hashedPassword: '',
   };
-  socket.emit('room:create', room);
-  console.log('[DEBUG] room:create', room);
+  socket.emit('chat:create', room);
+  console.log('chat:create', room);
 };
 
 const Chat = () => {
@@ -50,13 +50,13 @@ const Chat = () => {
 
   // dbに保存ができたら,backendからreceiveする
   useEffect(() => {
-    socket.on('room:create', (data: ChatRoom) => {
-      console.log('room:create', data);
+    socket.on('chat:create', (data: ChatRoom) => {
+      console.log('chat:create', data);
       setRooms((rooms) => [...rooms, data]);
     });
 
     return () => {
-      socket.off('room:create');
+      socket.off('chat:create');
     };
   }, []);
 

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -35,27 +35,28 @@ const createChatRoom = () => {
 const Chat = () => {
   const [rooms, setRooms] = useState<ChatRoom[]>([]);
 
-  // TODO: fetchに変更する
   useEffect(() => {
-    socket.on('chat:connected', (data: ChatRoom[]) => {
-      console.log('[DEBUG] chat:connected', data);
+    socket.on('chat:getRooms', (data: ChatRoom[]) => {
+      console.log('chat:getRooms', data);
       setRooms(data);
     });
+    // chatroom一覧を取得する
+    socket.emit('chat:getRooms');
 
     return () => {
-      socket.off('chat:connected');
+      socket.off('chat:getRooms');
     };
   }, []);
 
   // dbに保存ができたら,backendからreceiveする
   useEffect(() => {
-    socket.on('room:created', (data: ChatRoom) => {
-      console.log('[DEBUG] room:created', data);
+    socket.on('room:create', (data: ChatRoom) => {
+      console.log('room:create', data);
       setRooms((rooms) => [...rooms, data]);
     });
 
     return () => {
-      socket.off('room:created');
+      socket.off('room:create');
     };
   }, []);
 


### PR DESCRIPTION
### 概要

**原因**
- これまでLifeCycle Hookを使用して、socketに接続時にデータを受け取っていた

**対応**
- useEffectでその都度、ChatGatewayからデータを送ってもらうように修正した

### 関連issue
- resolve #53 