### PR TITLE
チャットルームを公開、非公開、パスワード付きの3パターン作成できるようにする

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,4 +7,9 @@
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": true // ファイル保存時に ESLint でフォーマット
   },
+  "eslint.workingDirectories": [
+    "frontend",
+    "backend"
+  ],
+  "nuxt.isNuxtApp": false
 }

--- a/backend/prisma/migrations/20221112163623_chatroom_v2/migration.sql
+++ b/backend/prisma/migrations/20221112163623_chatroom_v2/migration.sql
@@ -1,0 +1,62 @@
+/*
+  Warnings:
+
+  - You are about to drop the column `roomId` on the `Message` table. All the data in the column will be lost.
+  - You are about to drop the `ChatRoom` table. If the table is not empty, all the data it contains will be lost.
+  - Added the required column `chatroomId` to the `Message` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- CreateEnum
+CREATE TYPE "ChatroomType" AS ENUM ('PUBLIC', 'PRIVATE', 'PROTECTED');
+
+-- DropForeignKey
+ALTER TABLE "Message" DROP CONSTRAINT "Message_roomId_fkey";
+
+-- AlterTable
+ALTER TABLE "Message" DROP COLUMN "roomId",
+ADD COLUMN     "chatroomId" INTEGER NOT NULL,
+ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;
+
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "updatedAt" SET DEFAULT CURRENT_TIMESTAMP,
+ALTER COLUMN "hashedPassword" DROP NOT NULL;
+
+-- DropTable
+DROP TABLE "ChatRoom";
+
+-- CreateTable
+CREATE TABLE "Chatroom" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "name" TEXT NOT NULL,
+    "type" "ChatroomType" NOT NULL DEFAULT 'PUBLIC',
+    "ownerId" INTEGER NOT NULL,
+    "hashedPassword" TEXT,
+
+    CONSTRAINT "Chatroom_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "ChatroomAdmin" (
+    "id" SERIAL NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "chatroomId" INTEGER NOT NULL,
+    "userId" INTEGER NOT NULL,
+
+    CONSTRAINT "ChatroomAdmin_pkey" PRIMARY KEY ("id")
+);
+
+-- AddForeignKey
+ALTER TABLE "Chatroom" ADD CONSTRAINT "Chatroom_ownerId_fkey" FOREIGN KEY ("ownerId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "Message" ADD CONSTRAINT "Message_chatroomId_fkey" FOREIGN KEY ("chatroomId") REFERENCES "Chatroom"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatroomAdmin" ADD CONSTRAINT "ChatroomAdmin_chatroomId_fkey" FOREIGN KEY ("chatroomId") REFERENCES "Chatroom"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "ChatroomAdmin" ADD CONSTRAINT "ChatroomAdmin_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -8,38 +8,64 @@ datasource db {
 }
 
 model User {
-  id             Int       @id @default(autoincrement())
-  createdAt      DateTime  @default(now())
-  updatedAt      DateTime  @updatedAt
+  id             Int             @id @default(autoincrement())
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @default(now()) @updatedAt
   name           String
-  email          String    @unique
-  hashedPassword String
-  Message        Message[]
+  email          String          @unique
+  hashedPassword String?
+  message        Message[]
+  chatroom       Chatroom[]
+  chatroomAdmin  ChatroomAdmin[]
 }
 
-model ChatRoom {
-  id             Int       @id @default(autoincrement())
+// オーナー -> チャットルーム作成者(管理者権限も持つ)
+// 管理者   -> あとから追加できる(複数人)
+model Chatroom {
+  id             Int             @id @default(autoincrement())
+  createdAt      DateTime        @default(now())
+  updatedAt      DateTime        @default(now()) @updatedAt
   name           String
-  type           Boolean // TODO: private or public(DMは別にする?)
-  author         String // 最初は作成者にする -> 後で変更できるようにする
-  hashedPassword String
+  type           ChatroomType    @default(PUBLIC)
+  owner          User            @relation(fields: [ownerId], references: [id])
+  ownerId        Int
+  hashedPassword String?
   message        Message[]
+  admin          ChatroomAdmin[]
+}
+
+enum ChatroomType {
+  PUBLIC
+  PRIVATE
+  PROTECTED
 }
 
 model Message {
-  id       Int      @id @default(autoincrement())
-  roomId   Int
-  userId   Int
-  message  String
-  chatRoom ChatRoom @relation(fields: [roomId], references: [id], onDelete: Cascade) // Roomが消されたらメッセージも削除される
-  user     User     @relation(fields: [userId], references: [id])
+  id         Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @default(now()) @updatedAt
+  message    String
+  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade) // Roomが消されたらメッセージも削除される
+  chatroomId Int
+  user       User     @relation(fields: [userId], references: [id])
+  userId     Int
+}
+
+model ChatroomAdmin {
+  id         Int      @id @default(autoincrement())
+  createdAt  DateTime @default(now())
+  updatedAt  DateTime @default(now()) @updatedAt
+  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade) // Roomが消されたらメッセージも削除される
+  chatroomId Int
+  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  userId     Int
 }
 
 model GameRecord {
-  id          Int       @id @default(autoincrement())
+  id          Int      @id @default(autoincrement())
   winnerName  String
   loserName   String
   winnerScore Int
   loserScore  Int
-  createdAt   DateTime  @default(now())
+  createdAt   DateTime @default(now())
 }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -1,29 +1,31 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
-import { ChatRoom, Message, Prisma } from '@prisma/client';
+import { Chatroom, Message, Prisma } from '@prisma/client';
+import { CreateChatroomDto } from './dto/create-chatroom.dto';
+import { CreateMessageDto } from './dto/create-message.dto';
 
 @Injectable()
 export class ChatService {
   constructor(private prisma: PrismaService) {}
 
-  async chatRoom(
-    charRoomWhereUniqueInput: Prisma.ChatRoomWhereUniqueInput,
-  ): Promise<ChatRoom | null> {
-    return this.prisma.chatRoom.findUnique({
-      where: charRoomWhereUniqueInput,
+  async findOne(
+    chatroomWhereUniqueInput: Prisma.ChatroomWhereUniqueInput,
+  ): Promise<Chatroom | null> {
+    return this.prisma.chatroom.findUnique({
+      where: chatroomWhereUniqueInput,
     });
   }
 
-  async chatRooms(params: {
+  async findAll(params: {
     skip?: number;
     take?: number;
-    cursor?: Prisma.ChatRoomWhereUniqueInput;
-    where?: Prisma.ChatRoomWhereInput;
-    orderBy?: Prisma.ChatRoomOrderByWithRelationInput;
-  }): Promise<ChatRoom[]> {
+    cursor?: Prisma.ChatroomWhereUniqueInput;
+    where?: Prisma.ChatroomWhereInput;
+    orderBy?: Prisma.ChatroomOrderByWithRelationInput;
+  }): Promise<Chatroom[]> {
     const { skip, take, cursor, where, orderBy } = params;
 
-    return this.prisma.chatRoom.findMany({
+    return this.prisma.chatroom.findMany({
       skip,
       take,
       cursor,
@@ -32,28 +34,31 @@ export class ChatService {
     });
   }
 
-  async createChatRoom(data: Prisma.ChatRoomCreateInput): Promise<ChatRoom> {
-    return this.prisma.chatRoom.create({
-      data,
+  async create(CreateChatroomDto: CreateChatroomDto): Promise<Chatroom> {
+    console.log(CreateChatroomDto);
+    const chatroom = await this.prisma.chatroom.create({
+      data: {
+        ...CreateChatroomDto,
+      },
     });
+
+    return chatroom;
   }
 
-  async updateChatRoom(params: {
-    where: Prisma.ChatRoomWhereUniqueInput;
-    data: Prisma.ChatRoomUpdateInput;
-  }): Promise<ChatRoom> {
+  async update(params: {
+    where: Prisma.ChatroomWhereUniqueInput;
+    data: Prisma.ChatroomUpdateInput;
+  }): Promise<Chatroom> {
     const { where, data } = params;
 
-    return this.prisma.chatRoom.update({
+    return this.prisma.chatroom.update({
       data,
       where,
     });
   }
 
-  async deleteChatRoom(
-    where: Prisma.ChatRoomWhereUniqueInput,
-  ): Promise<ChatRoom> {
-    return this.prisma.chatRoom.delete({
+  async remove(where: Prisma.ChatroomWhereUniqueInput): Promise<Chatroom> {
+    return this.prisma.chatroom.delete({
       where,
     });
   }
@@ -61,8 +66,16 @@ export class ChatService {
   /**
    * TODO: 引数をDTOにしたい
    */
-  async addMessage(data: Prisma.MessageUncheckedCreateInput): Promise<Message> {
-    return this.prisma.message.create({ data });
+  async addMessage(createMessageDto: CreateMessageDto): Promise<Message> {
+    console.log(createMessageDto);
+
+    const Message = await this.prisma.message.create({
+      data: {
+        ...createMessageDto,
+      },
+    });
+
+    return Message;
   }
 
   /**
@@ -70,9 +83,9 @@ export class ChatService {
    * TODO: 引数に応じて取得する数を調整する
    */
   async findMessages(
-    charRoomWhereUniqueInput: Prisma.ChatRoomWhereUniqueInput,
+    charRoomWhereUniqueInput: Prisma.ChatroomWhereUniqueInput,
   ): Promise<Message[] | null> {
-    const res = await this.prisma.chatRoom.findUnique({
+    const res = await this.prisma.chatroom.findUnique({
       where: charRoomWhereUniqueInput,
       include: {
         message: true,

--- a/backend/src/chat/dto/create-chatroom.dto.ts
+++ b/backend/src/chat/dto/create-chatroom.dto.ts
@@ -1,0 +1,26 @@
+import {
+  IsNotEmpty,
+  IsNumber,
+  IsString,
+  IsEnum,
+  IsOptional,
+} from 'class-validator';
+import { ChatroomType } from '@prisma/client';
+
+export class CreateChatroomDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+
+  @IsEnum(ChatroomType)
+  @IsNotEmpty()
+  type: ChatroomType;
+
+  @IsNumber()
+  @IsNotEmpty()
+  ownerId: number;
+
+  @IsString()
+  @IsOptional()
+  hashedPassword?: string;
+}

--- a/backend/src/chat/dto/create-message.dto.ts
+++ b/backend/src/chat/dto/create-message.dto.ts
@@ -1,13 +1,13 @@
 import { IsNotEmpty, IsInt, IsString } from 'class-validator';
 
-export class PostMessagesDto {
+export class CreateMessageDto {
   @IsNotEmpty()
   @IsInt()
   userId: number;
 
   @IsNotEmpty()
   @IsInt()
-  roomId: number;
+  chatroomId: number;
 
   @IsNotEmpty()
   @IsString()

--- a/frontend/components/chat/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/ChatroomCreateButton.tsx
@@ -1,0 +1,155 @@
+import { useState, memo, useCallback } from 'react';
+import { Socket } from 'socket.io-client';
+import {
+  Button,
+  TextField,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  InputLabel,
+  Select,
+  SelectChangeEvent,
+  MenuItem,
+  FormControl,
+} from '@mui/material';
+import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded';
+import { CreateChatroom, ChatroomType, CHATROOM_TYPE } from 'types/chat';
+
+type Props = {
+  socket: Socket;
+};
+
+export const ChatroomCreateButton = memo(function ChatroomCreateButton({
+  socket,
+}: Props) {
+  const [name, setName] = useState('');
+  const [open, setOpen] = useState(false);
+  const [password, setPassword] = useState('');
+  const [roomType, setRoomType] = useState<ChatroomType>(CHATROOM_TYPE.PUBLIC);
+
+  const initDialog = useCallback(() => {
+    setName('');
+    setPassword('');
+    setRoomType(CHATROOM_TYPE.PUBLIC);
+  }, [name, password, roomType]);
+
+  const handleChangeType = (event: SelectChangeEvent) => {
+    setRoomType(event.target.value as ChatroomType);
+  };
+
+  const handleOpen = useCallback(() => {
+    setOpen(true);
+  }, [open]);
+
+  const handleClose = useCallback(() => {
+    setOpen(false);
+    initDialog();
+  }, [open]);
+
+  const getRooms = useCallback(() => {
+    socket.emit('chat:getRooms');
+  }, [socket]);
+
+  const createChatroom = useCallback(
+    (room: CreateChatroom) => {
+      socket.emit('chat:create', room);
+    },
+    [socket],
+  );
+
+  const handleSubmit = useCallback(() => {
+    if (
+      name.length === 0 ||
+      (roomType === CHATROOM_TYPE.PROTECTED && password.length === 0)
+    ) {
+      handleClose();
+
+      return;
+    }
+
+    const room: CreateChatroom = {
+      name: name,
+      type: roomType,
+      ownerId: 1, // TODO:userのidに変更する
+    };
+    if (roomType === CHATROOM_TYPE.PROTECTED) {
+      room.hashedPassword = password;
+    }
+    createChatroom(room);
+    getRooms();
+    handleClose();
+  }, [name]);
+
+  return (
+    <>
+      <Button
+        color="primary"
+        variant="outlined"
+        endIcon={
+          <AddCircleOutlineRounded color="primary" sx={{ fontSize: 32 }} />
+        }
+        fullWidth={true}
+        style={{ justifyContent: 'flex-start' }}
+        onClick={handleOpen}
+      >
+        チャットルーム作成
+      </Button>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Subscribe</DialogTitle>
+        <DialogContent>
+          <TextField
+            autoFocus
+            margin="dense"
+            id="name"
+            label="Room name"
+            type="text"
+            value={name}
+            onChange={(e) => {
+              setName(e.target.value);
+            }}
+            fullWidth
+            variant="standard"
+          />
+        </DialogContent>
+        {roomType === CHATROOM_TYPE.PROTECTED && (
+          <DialogContent>
+            <TextField
+              autoFocus
+              margin="dense"
+              id="name"
+              label="Password"
+              type="text"
+              value={password}
+              onChange={(e) => {
+                setPassword(e.target.value);
+              }}
+              fullWidth
+              variant="standard"
+            />
+          </DialogContent>
+        )}
+        <DialogContent>
+          <FormControl sx={{ m: 1, minWidth: 120 }}>
+            <InputLabel id="room-type-select-label">Type</InputLabel>
+            <Select
+              labelId="room-type-select-label"
+              id="room-type"
+              value={roomType}
+              label="type"
+              onChange={handleChangeType}
+            >
+              <MenuItem value={CHATROOM_TYPE.PUBLIC}>Public</MenuItem>
+              <MenuItem value={CHATROOM_TYPE.PRIVATE}>Private</MenuItem>
+              <MenuItem value={CHATROOM_TYPE.PROTECTED}>Protected</MenuItem>
+            </Select>
+          </FormControl>
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleSubmit}>Submit</Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+});

--- a/frontend/components/chat/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/ChatroomCreateButton.tsx
@@ -79,7 +79,7 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
     createChatroom(room);
     getRooms();
     handleClose();
-  }, [name]);
+  }, [name, roomType, password]);
 
   return (
     <>

--- a/frontend/components/chat/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/ChatroomCreateButton.tsx
@@ -14,7 +14,7 @@ import {
   FormControl,
 } from '@mui/material';
 import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded';
-import { CreateChatroom, ChatroomType, CHATROOM_TYPE } from 'types/chat';
+import { CreateChatroomInfo, ChatroomType, CHATROOM_TYPE } from 'types/chat';
 
 type Props = {
   socket: Socket;
@@ -52,7 +52,7 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
   }, [socket]);
 
   const createChatroom = useCallback(
-    (room: CreateChatroom) => {
+    (room: CreateChatroomInfo) => {
       socket.emit('chat:create', room);
     },
     [socket],
@@ -68,7 +68,7 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
       return;
     }
 
-    const room: CreateChatroom = {
+    const room: CreateChatroomInfo = {
       name: name,
       type: roomType,
       ownerId: 1, // TODO:userのidに変更する

--- a/frontend/components/chat/ChatroomListItem.tsx
+++ b/frontend/components/chat/ChatroomListItem.tsx
@@ -1,22 +1,13 @@
-import ListItem from '@mui/material/ListItem';
-import IconButton from '@mui/material/IconButton';
-import ListItemText from '@mui/material/ListItemText';
+import { ListItem, IconButton, ListItemText } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
-
-type ChatRoom = {
-  id: number;
-  name: string;
-  type: boolean;
-  author: string;
-  hashedPassword?: string;
-};
+import { Chatroom } from 'types/chat';
 
 type Props = {
-  room: ChatRoom;
+  room: Chatroom;
   joinRoom: (id: number) => void;
 };
 
-export const ChatRoomListItem = ({ room, joinRoom }: Props) => {
+export const ChatroomListItem = ({ room, joinRoom }: Props) => {
   if (room === undefined) {
     return null;
   }

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -1,33 +1,12 @@
 import { useState, useEffect } from 'react';
 import { io, Socket } from 'socket.io-client';
-import {
-  Button,
-  List,
-  TextField,
-  IconButton,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  InputLabel,
-  Select,
-  SelectChangeEvent,
-  MenuItem,
-  FormControl,
-} from '@mui/material';
-
+import { List, TextField, IconButton } from '@mui/material';
 import Grid from '@mui/material/Unstable_Grid2';
-import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded';
 import SendIcon from '@mui/icons-material/Send';
 import { Header } from 'components/common/Header';
 import { ChatroomListItem } from 'components/chat/ChatroomListItem';
-import {
-  CreateChatroom,
-  Chatroom,
-  Message,
-  ChatroomType,
-  CHATROOM_TYPE,
-} from 'types/chat';
+import { ChatroomCreateButton } from 'components/chat/ChatroomCreateButton';
+import { Chatroom, Message } from 'types/chat';
 
 const appBarHeight = '64px';
 
@@ -129,65 +108,6 @@ const Chat = () => {
     }
   };
 
-  const [chatroomType, setChatroomType] = useState<ChatroomType>(
-    CHATROOM_TYPE.PUBLIC,
-  );
-  const handleChange = (event: SelectChangeEvent) => {
-    console.log('ChatroomType:', event.target.value);
-    setChatroomType(event.target.value as ChatroomType);
-  };
-
-  const [open, setOpen] = useState(false);
-  const handleClickOpen = () => {
-    setOpen(true);
-  };
-
-  const [name, setName] = useState('');
-  const [password, setPassword] = useState('');
-
-  const initDialog = () => {
-    setName('');
-    setChatroomType(CHATROOM_TYPE.PUBLIC);
-    setPassword('');
-  };
-
-  const handleClose = () => {
-    setOpen(false);
-    initDialog();
-  };
-
-  const getRooms = () => {
-    if (!socket) return;
-
-    socket.emit('chat:getRooms');
-  };
-
-  const createChatroom = (room: CreateChatroom) => {
-    if (!socket) return;
-    console.log('chat:create', room);
-    socket.emit('chat:create', room);
-  };
-
-  const handleSubmit = () => {
-    if (!socket || name.length === 0) {
-      handleClose();
-
-      return;
-    }
-
-    const room: CreateChatroom = {
-      name: name,
-      type: chatroomType,
-      ownerId: 1, // TODO:userのidに変更する
-    };
-    if (chatroomType === CHATROOM_TYPE.PROTECTED) {
-      room.hashedPassword = password;
-    }
-    createChatroom(room);
-    getRooms();
-    handleClose();
-  };
-
   return (
     <>
       <Header title="Chatroom" />
@@ -205,75 +125,7 @@ const Chat = () => {
             borderBottom: '1px solid',
           }}
         >
-          {/* TODO: Buttonコンポーネント作る */}
-          <Button
-            color="primary"
-            variant="outlined"
-            endIcon={
-              <AddCircleOutlineRounded color="primary" sx={{ fontSize: 32 }} />
-            }
-            fullWidth={true}
-            style={{ justifyContent: 'flex-start' }}
-            onClick={handleClickOpen}
-          >
-            チャットルーム作成
-          </Button>
-          <Dialog open={open} onClose={handleClose}>
-            <DialogTitle>Subscribe</DialogTitle>
-            <DialogContent>
-              <TextField
-                autoFocus
-                margin="dense"
-                id="name"
-                label="Room name"
-                type="text"
-                value={name}
-                onChange={(e) => {
-                  setName(e.target.value);
-                }}
-                fullWidth
-                variant="standard"
-              />
-            </DialogContent>
-            {chatroomType === CHATROOM_TYPE.PROTECTED && (
-              <DialogContent>
-                <TextField
-                  autoFocus
-                  margin="dense"
-                  id="name"
-                  label="Password"
-                  type="text"
-                  value={password}
-                  onChange={(e) => {
-                    setPassword(e.target.value);
-                  }}
-                  fullWidth
-                  variant="standard"
-                />
-              </DialogContent>
-            )}
-            <DialogContent>
-              <FormControl sx={{ m: 1, minWidth: 120 }}>
-                <InputLabel id="room-type-select-label">Type</InputLabel>
-                <Select
-                  labelId="room-type-select-label"
-                  id="room-type"
-                  value={chatroomType}
-                  label="ChatroomType"
-                  onChange={handleChange}
-                >
-                  <MenuItem value={CHATROOM_TYPE.PUBLIC}>Public</MenuItem>
-                  <MenuItem value={CHATROOM_TYPE.PRIVATE}>Private</MenuItem>
-                  <MenuItem value={CHATROOM_TYPE.PROTECTED}>Protected</MenuItem>
-                </Select>
-              </FormControl>
-            </DialogContent>
-
-            <DialogActions>
-              <Button onClick={handleClose}>Cancel</Button>
-              <Button onClick={handleSubmit}>Subscribe</Button>
-            </DialogActions>
-          </Dialog>
+          {socket !== undefined && <ChatroomCreateButton socket={socket} />}
           <List dense={false}>
             {rooms.map((room, i) => (
               <ChatroomListItem key={i} room={room} joinRoom={joinRoom} />

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -1,31 +1,38 @@
 import { useState, useEffect } from 'react';
 import { io, Socket } from 'socket.io-client';
-import { Button, List, TextField, IconButton } from '@mui/material';
+import {
+  Button,
+  List,
+  TextField,
+  IconButton,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  InputLabel,
+  Select,
+  SelectChangeEvent,
+  MenuItem,
+  FormControl,
+} from '@mui/material';
+
 import Grid from '@mui/material/Unstable_Grid2';
 import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded';
 import SendIcon from '@mui/icons-material/Send';
 import { Header } from 'components/common/Header';
-import { ChatRoomListItem } from 'components/chat/ChatRoomListItem';
-
-type ChatRoom = {
-  id: number;
-  name: string;
-  type: boolean;
-  author: string;
-  hashedPassword?: string;
-};
-
-type Message = {
-  userId: number;
-  roomId: number;
-  message: string;
-  userName?: string;
-};
+import { ChatroomListItem } from 'components/chat/ChatroomListItem';
+import {
+  CreateChatroom,
+  Chatroom,
+  Message,
+  ChatroomType,
+  CHATROOM_TYPE,
+} from 'types/chat';
 
 const appBarHeight = '64px';
 
 const Chat = () => {
-  const [rooms, setRooms] = useState<ChatRoom[]>([]);
+  const [rooms, setRooms] = useState<Chatroom[]>([]);
   const [text, setText] = useState('');
   const [messages, setMessages] = useState<Message[]>([]);
   const [currentRoomId, setCurrentRoomId] = useState(0);
@@ -43,7 +50,7 @@ const Chat = () => {
   useEffect(() => {
     if (!socket) return;
 
-    socket.on('chat:getRooms', (data: ChatRoom[]) => {
+    socket.on('chat:getRooms', (data: Chatroom[]) => {
       console.log('chat:getRooms', data);
       setRooms(data);
     });
@@ -104,36 +111,81 @@ const Chat = () => {
   // send a message to the server
   const sendMessage = () => {
     if (!socket) return;
-    const message = { userId: 1, roomId: currentRoomId, message: text };
+
+    // TODO: userIdをuserから取得できるようにする置き換える
+    const message = { userId: 1, chatroomId: currentRoomId, message: text };
+    console.log('sendMessage:', message);
+
     socket.emit('chat:sendMessage', message);
     setText('');
   };
 
   const joinRoom = (id: number) => {
     if (!socket) return;
-
+    console.log('joinRoom:', id);
     const res = socket.emit('chat:joinRoom', id);
     if (res) {
       setCurrentRoomId(id);
     }
   };
 
-  // TODO: name以外も指定できるようにする
-  const createChatRoom = () => {
+  const [chatroomType, setChatroomType] = useState<ChatroomType>(
+    CHATROOM_TYPE.PUBLIC,
+  );
+  const handleChange = (event: SelectChangeEvent) => {
+    console.log('ChatroomType:', event.target.value);
+    setChatroomType(event.target.value as ChatroomType);
+  };
+
+  const [open, setOpen] = useState(false);
+  const handleClickOpen = () => {
+    setOpen(true);
+  };
+
+  const [name, setName] = useState('');
+  const [password, setPassword] = useState('');
+
+  const initDialog = () => {
+    setName('');
+    setChatroomType(CHATROOM_TYPE.PUBLIC);
+    setPassword('');
+  };
+
+  const handleClose = () => {
+    setOpen(false);
+    initDialog();
+  };
+
+  const getRooms = () => {
     if (!socket) return;
-    const name = window.prompt('チャンネル名を入力してください');
-    if (name === null || name.length === 0) {
-      return;
-    }
-    const room = {
-      name: name,
-      type: true,
-      author: 'admin',
-      hashedPassword: '',
-    };
+
+    socket.emit('chat:getRooms');
+  };
+
+  const createChatroom = (room: CreateChatroom) => {
+    if (!socket) return;
     console.log('chat:create', room);
     socket.emit('chat:create', room);
-    socket.emit('chat:getRooms');
+  };
+
+  const handleSubmit = () => {
+    if (!socket || name.length === 0) {
+      handleClose();
+
+      return;
+    }
+
+    const room: CreateChatroom = {
+      name: name,
+      type: chatroomType,
+      ownerId: 1, // TODO:userのidに変更する
+    };
+    if (chatroomType === CHATROOM_TYPE.PROTECTED) {
+      room.hashedPassword = password;
+    }
+    createChatroom(room);
+    getRooms();
+    handleClose();
   };
 
   return (
@@ -162,13 +214,69 @@ const Chat = () => {
             }
             fullWidth={true}
             style={{ justifyContent: 'flex-start' }}
-            onClick={createChatRoom}
+            onClick={handleClickOpen}
           >
             チャットルーム作成
           </Button>
+          <Dialog open={open} onClose={handleClose}>
+            <DialogTitle>Subscribe</DialogTitle>
+            <DialogContent>
+              <TextField
+                autoFocus
+                margin="dense"
+                id="name"
+                label="Room name"
+                type="text"
+                value={name}
+                onChange={(e) => {
+                  setName(e.target.value);
+                }}
+                fullWidth
+                variant="standard"
+              />
+            </DialogContent>
+            {chatroomType === CHATROOM_TYPE.PROTECTED && (
+              <DialogContent>
+                <TextField
+                  autoFocus
+                  margin="dense"
+                  id="name"
+                  label="Password"
+                  type="text"
+                  value={password}
+                  onChange={(e) => {
+                    setPassword(e.target.value);
+                  }}
+                  fullWidth
+                  variant="standard"
+                />
+              </DialogContent>
+            )}
+            <DialogContent>
+              <FormControl sx={{ m: 1, minWidth: 120 }}>
+                <InputLabel id="room-type-select-label">Type</InputLabel>
+                <Select
+                  labelId="room-type-select-label"
+                  id="room-type"
+                  value={chatroomType}
+                  label="ChatroomType"
+                  onChange={handleChange}
+                >
+                  <MenuItem value={CHATROOM_TYPE.PUBLIC}>Public</MenuItem>
+                  <MenuItem value={CHATROOM_TYPE.PRIVATE}>Private</MenuItem>
+                  <MenuItem value={CHATROOM_TYPE.PROTECTED}>Protected</MenuItem>
+                </Select>
+              </FormControl>
+            </DialogContent>
+
+            <DialogActions>
+              <Button onClick={handleClose}>Cancel</Button>
+              <Button onClick={handleSubmit}>Subscribe</Button>
+            </DialogActions>
+          </Dialog>
           <List dense={false}>
             {rooms.map((room, i) => (
-              <ChatRoomListItem key={i} room={room} joinRoom={joinRoom} />
+              <ChatroomListItem key={i} room={room} joinRoom={joinRoom} />
             ))}
           </List>
         </Grid>
@@ -181,32 +289,34 @@ const Chat = () => {
         >
           <h2>チャットスペース</h2>
           <div style={{ marginLeft: 5, marginRight: 5 }}>
-            <TextField
-              autoFocus
-              fullWidth
-              label="Message"
-              id="Message"
-              type="text"
-              variant="standard"
-              size="small"
-              value={text}
-              placeholder={`#roomへメッセージを送信`}
-              onKeyPress={(e) => {
-                if (e.key === 'Enter') {
-                  sendMessage();
-                }
-              }}
-              onChange={(e) => {
-                setText(e.target.value);
-              }}
-              InputProps={{
-                endAdornment: (
-                  <IconButton onClick={sendMessage}>
-                    <SendIcon />
-                  </IconButton>
-                ),
-              }}
-            />
+            <div style={{ display: 'flex', alignItems: 'end' }}>
+              <TextField
+                autoFocus
+                fullWidth
+                label="Message"
+                id="Message"
+                type="text"
+                variant="standard"
+                size="small"
+                value={text}
+                placeholder={`#roomへメッセージを送信`}
+                onKeyPress={(e) => {
+                  if (e.key === 'Enter') {
+                    sendMessage();
+                  }
+                }}
+                onChange={(e) => {
+                  setText(e.target.value);
+                }}
+                InputProps={{
+                  endAdornment: (
+                    <IconButton onClick={sendMessage}>
+                      <SendIcon />
+                    </IconButton>
+                  ),
+                }}
+              />
+            </div>
             <p>
               <strong>Talk Room</strong>
             </p>

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -1,0 +1,28 @@
+export type Chatroom = {
+  id: number;
+  name: string;
+  type: string;
+  ownerId: number;
+  hashedPassword?: string;
+};
+
+export type CreateChatroom = {
+  name: string;
+  type: string;
+  ownerId: number;
+  hashedPassword?: string;
+};
+
+export type Message = {
+  ChatroomId: number;
+  userId: number;
+  message: string;
+};
+
+export const CHATROOM_TYPE = {
+  PUBLIC: 'PUBLIC',
+  PRIVATE: 'PRIVATE',
+  PROTECTED: 'PROTECTED',
+} as const;
+
+export type ChatroomType = typeof CHATROOM_TYPE[keyof typeof CHATROOM_TYPE];

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -6,7 +6,7 @@ export type Chatroom = {
   hashedPassword?: string;
 };
 
-export type CreateChatroom = {
+export type CreateChatroomInfo = {
   name: string;
   type: string;
   ownerId: number;


### PR DESCRIPTION
### 概要
- チャットルームを3種類作成できるようにした
  - 公開
  - 非公開
  - パスワード付き
- 作成できるだけで機能面は今後実装する

### 実装詳細
- chatroomテーブルに以下の要素を追加した
  - type(公開、非公開、パスワードで保護)
  - 作成者(owner)
  - 管理者(admin)
- チャットルーム作成とメッセージの送受信にDTOを導入した

### その他
- React.memoとuseCallbackの説明 -> https://blog.uhy.ooo/entry/2021-02-23/usecallback-custom-hooks/
- 以下については別issueで対応します
  - チャットルームを作成してリロードしないと表示されない(そもそもロジックを変える必要がある)
  - パスワードのハッシュ化

### テスト手順
- npx migrateを実行
- userを作成する
- チャットルームをpublic、private、protected(パスワード付き)で作成する

上記実行後に確認する
- 正しくデータが保存されていること
- メッセージの送受信が正しく行えること

### 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/77