### PR TITLE
プレーヤーのバーの操作性向上

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -78,7 +78,7 @@ export class GameGateway {
   static barLength = 100;
   static matchPoint = 3;
   static boardWidth = 1000;
-  static barSpeed = 30;
+  static barSpeed = 10;
 
   @WebSocketServer()
   server: Server;
@@ -187,12 +187,12 @@ export class GameGateway {
       room.matchPoint = data.matchPoint;
       switch (data.difficulty) {
         case 'Normal':
-          room.barSpeed = 40;
-          room.ballVec.speed = 4;
+          room.barSpeed = 20;
+          room.ballVec.speed = 5;
           break;
         case 'Hard':
-          room.barSpeed = 50;
-          room.ballVec.speed = 5;
+          room.barSpeed = 30;
+          room.ballVec.speed = 7;
           break;
         default:
           break;


### PR DESCRIPTION
# 概要

プレーヤーのバーがなめらかに動くように修正しました

# 受入条件

Easy/Normal/Hardでそれぞれ遊んでみて、いい感じにバーが動くか確認

# Next step

- 前回の定例のときに、ボールを正方形にするとか、色々追加の実装の話をしては見たんですが、一旦、ゲームの基本的な実装はこれで終わりってことにして、バックエンドのDBとのつなぎこみとか、プロフィールとかの実装に移ろうかなと思っています (というわけで、かなり小さな塊でもPRになっちゃったんですが、一旦一区切りということで出しています)
- 課題文の中に`it must be faithful to the original Pong (1972).`という文があるので、「オリジナルのPongに忠実、と言えるためには、ここはもうちょっと丁寧に本家に近づけて実装したほうがいいんじゃない？」という点があれば、是非コメントください (ちなみにオリジナルのPongのプレー画面は[こんな感じ](https://www.youtube.com/watch?v=fhd7FfGCdCo)です。)

# Related issues

- resolve #88 
