### PR TITLE
ユーザ名をregisterフォームで登録する。

### DIFF
--- a/backend/prisma/migrations/20221117073124_user_v2/migration.sql
+++ b/backend/prisma/migrations/20221117073124_user_v2/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - A unique constraint covering the columns `[name]` on the table `User` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- CreateIndex
+CREATE UNIQUE INDEX "User_name_key" ON "User"("name");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -11,7 +11,7 @@ model User {
   id             Int             @id @default(autoincrement())
   createdAt      DateTime        @default(now())
   updatedAt      DateTime        @default(now()) @updatedAt
-  name           String
+  name           String          @unique
   email          String          @unique
   hashedPassword String?
   message        Message[]

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -30,7 +30,7 @@ export class AuthController {
   @HttpCode(HttpStatus.OK)
   @Post('login')
   async login(
-    @Body() dto: AuthDto,
+    @Body() dto: Omit<AuthDto, 'username'>,
     @Res({ passthrough: true }) res: Response,
   ): Promise<Msg> {
     const jwt = await this.authService.login(dto);

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -35,7 +35,7 @@ export class AuthService {
       if (error instanceof PrismaClientKnownRequestError) {
         // Prismaが新規作成時に発行するエラー。
         if (error.code === 'P2002') {
-          throw new ForbiddenException('This email is already taken');
+          throw new ForbiddenException('email or username is already taken');
         }
       }
       throw error;

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -24,7 +24,7 @@ export class AuthService {
         data: {
           email: dto.email,
           hashedPassword: hashed,
-          name: '', //ここで設定せず空欄許可した方が良さそう。
+          name: dto.username,
         },
       });
 
@@ -42,7 +42,7 @@ export class AuthService {
     }
   }
 
-  async login(dto: AuthDto): Promise<Jwt> {
+  async login(dto: Omit<AuthDto, 'username'>): Promise<Jwt> {
     const user = await this.prisma.user.findUnique({
       where: {
         email: dto.email,

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -8,4 +8,7 @@ export class AuthDto {
   @IsNotEmpty()
   @MinLength(5)
   password: string;
+
+  @IsNotEmpty()
+  username: string;
 }

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -9,6 +9,7 @@ export class AuthDto {
   @MinLength(5)
   password: string;
 
+  @IsString()
   @IsNotEmpty()
   username: string;
 }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint '{components,pages,store,hooks}/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint --fix '{components,pages,store,hooks}/**/*.{js,jsx,ts,tsx}'",
     "format": "prettier --write \"{components,pages,store,hooks}/**/*.{js,jsx,ts,tsx}\"",
+    "preinstall": "typesync || :",
     "prepare": "cd .. && husky install .config/.husky"
   },
   "dependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,7 +9,6 @@
     "lint": "eslint '{components,pages,store,hooks}/**/*.{js,jsx,ts,tsx}'",
     "lint:fix": "eslint --fix '{components,pages,store,hooks}/**/*.{js,jsx,ts,tsx}'",
     "format": "prettier --write \"{components,pages,store,hooks}/**/*.{js,jsx,ts,tsx}\"",
-    "preinstall": "typesync || :",
     "prepare": "cd .. && husky install .config/.husky"
   },
   "dependencies": {
@@ -35,6 +34,7 @@
   "devDependencies": {
     "@emotion/react": "^11.10.4",
     "@emotion/styled": "^11.10.4",
+    "@hookform/resolvers": "^2.9.10",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.10",
     "@prisma/client": "^4.5.0",
@@ -56,6 +56,7 @@
     "prettier": "^2.7.1",
     "prettier-plugin-tailwindcss": "^0.1.13",
     "prisma": "^4.5.0",
+    "react-hook-form": "^7.39.4",
     "socket.io": "^4.5.3",
     "socket.io-client": "^4.5.3",
     "tailwindcss": "^3.2.1",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -98,7 +98,6 @@ const Home: NextPage = () => {
             control={control}
             render={({ field }) => (
               <TextField
-                required
                 placeholder="example@gmail.com"
                 fullWidth
                 size="small"
@@ -115,7 +114,6 @@ const Home: NextPage = () => {
             control={control}
             render={({ field }) => (
               <TextField
-                required
                 label="Password"
                 type={showPassword ? 'text' : 'password'}
                 error={errors.password ? true : false}
@@ -155,7 +153,6 @@ const Home: NextPage = () => {
               control={control}
               render={({ field }) => (
                 <TextField
-                  required
                   fullWidth
                   size="small"
                   sx={{ mb: 2 }}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -6,19 +6,23 @@ import axios from 'axios';
 import * as Yup from 'yup';
 import { IconDatabase } from '@tabler/icons';
 import Image from 'next/image';
-import { ShieldCheckIcon } from '@heroicons/react/solid';
-import { ExclamationCircleIcon } from '@heroicons/react/outline';
-import {
-  Anchor,
-  TextInput,
-  Button,
-  Group,
-  PasswordInput,
-  Alert,
-} from '@mantine/core';
-import { useForm, yupResolver } from '@mantine/form';
+import GppGoodIcon from '@mui/icons-material/GppGood';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import { yupResolver } from '@hookform/resolvers/yup';
 import { Layout } from '../components/Layout';
 import { AuthForm } from '../types';
+import {
+  Grid,
+  IconButton,
+  InputAdornment,
+  TextField,
+  Link,
+  Alert,
+  Button,
+  AlertTitle,
+} from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 
 const schema = Yup.object().shape({
   email: Yup.string().email('Invalid email').required('No email provided'),
@@ -31,28 +35,36 @@ const Home: NextPage = () => {
   const router = useRouter();
   const [isRegister, setIsRegister] = useState(false);
   const [error, setError] = useState('');
-  const form = useForm<AuthForm>({
-    validate: yupResolver(schema),
-    initialValues: {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const {
+    control,
+    formState: { errors },
+    handleSubmit,
+    clearErrors,
+  } = useForm<AuthForm>({
+    mode: 'onSubmit',
+    resolver: yupResolver(schema),
+    defaultValues: {
       email: '',
       password: '',
     },
   });
-  const handleSubmit = async () => {
+  const onSubmit: SubmitHandler<AuthForm> = async (data: AuthForm) => {
     try {
       if (process.env.NEXT_PUBLIC_API_URL) {
         if (isRegister) {
           const url_signup = `${process.env.NEXT_PUBLIC_API_URL}/auth/signup`;
           await axios.post(url_signup, {
-            email: form.values.email,
-            password: form.values.password,
+            email: data.email,
+            password: data.password,
+            username: data.username,
           });
         }
         await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth/login`, {
-          email: form.values.email,
-          password: form.values.password,
+          email: data.email,
+          password: data.password,
         });
-        form.reset();
         await router.push('/dashboard');
       }
     } catch (e) {
@@ -64,67 +76,128 @@ const Home: NextPage = () => {
 
   return (
     <Layout title="Auth">
-      <ShieldCheckIcon className="h-16 w-16 text-blue-500" />
-      {error && (
-        <Alert
-          my="md"
-          variant="filled"
-          icon={<ExclamationCircleIcon />}
-          title="Authorization Error"
-          color="red"
-          radius="md"
-        >
-          {error}
-        </Alert>
-      )}
-      <form onSubmit={form.onSubmit(handleSubmit as VoidFunction)}>
-        <TextInput
-          mt="md"
-          id="email"
-          label="Email*"
-          placeholder="example@gmail.com"
-          {...form.getInputProps('email')}
-        />
-        <PasswordInput
-          mt="md"
-          id="password"
-          placeholder="password"
-          label="Password*"
-          description="Must be min 5 char"
-          {...form.getInputProps('password')}
-        />
-        <Group mt="xl" position="apart">
-          <Anchor
-            component="button"
-            type="button"
-            size="xs"
-            className="text-gray-300"
-            onClick={() => {
-              setIsRegister(!isRegister);
-              setError('');
-            }}
-          >
-            {isRegister
-              ? 'Have an account? Login'
-              : "Don't have an account? Register"}
-          </Anchor>
-          <Button
-            leftIcon={<IconDatabase size={14} />}
-            color="cyan"
-            type="submit"
-          >
-            {isRegister ? 'Register' : 'Login'}
-          </Button>
-        </Group>
-      </form>
-      <br></br>
-      <a href="/auth42">
-        <Image src="/images/ico-42-logo.jpg" width={50} height={50} />
-      </a>
-      <br></br>
-      <a href="/google">
-        <Image src="/images/ico-google-logo-96.png" width={50} height={50} />
-      </a>
+      <Grid
+        container
+        justifyContent="center"
+        direction="column"
+        alignItems="center"
+        xs={3.5}
+      >
+        <GppGoodIcon color="primary" sx={{ width: 100, height: 100 }} />
+        {error && (
+          <Alert severity="error">
+            <AlertTitle>Authorization Error</AlertTitle>
+            {error}
+          </Alert>
+        )}
+        <form onSubmit={handleSubmit(onSubmit) as VoidFunction}>
+          <Controller
+            name="email"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                {...field}
+                placeholder="example@gmail.com"
+                fullWidth
+                size="small"
+                sx={{ mt: 2 }}
+                label="Email"
+                error={errors.email ? true : false}
+                helperText={errors.email?.message}
+              />
+            )}
+          />
+          <Controller
+            name="password"
+            control={control}
+            render={({ field }) => (
+              <TextField
+                label="Password"
+                type={showPassword ? 'text' : 'password'}
+                error={errors.password ? true : false}
+                helperText={
+                  errors.password
+                    ? errors.password?.message
+                    : 'Must be min 5 char'
+                }
+                InputProps={{
+                  endAdornment: (
+                    <InputAdornment position="end">
+                      <IconButton
+                        aria-label="toggle password visibility"
+                        onClick={() => {
+                          setShowPassword(!showPassword);
+                        }}
+                        onMouseDown={(event) => {
+                          event.preventDefault();
+                        }}
+                        edge="end"
+                      >
+                        {showPassword ? <VisibilityOffIcon /> : <Visibility />}
+                      </IconButton>
+                    </InputAdornment>
+                  ),
+                }}
+                size="small"
+                sx={{ mt: 4 }}
+                fullWidth
+                {...field}
+              />
+            )}
+          />
+          {isRegister && (
+            <Controller
+              name="username"
+              control={control}
+              render={({ field }) => (
+                <TextField
+                  {...field}
+                  fullWidth
+                  size="small"
+                  sx={{ my: 2 }}
+                  label="Username"
+                  error={errors.username ? true : false}
+                  helperText={errors.username?.message}
+                />
+              )}
+            />
+          )}
+          <Grid container justifyContent="space-between">
+            <Grid item>
+              <Link
+                component="button"
+                type="button"
+                variant="body2"
+                onClick={() => {
+                  clearErrors();
+                  setError('');
+                  setIsRegister(!isRegister);
+                }}
+              >
+                {isRegister
+                  ? 'Have an account? Login'
+                  : "Don't have an account? Register"}
+              </Link>
+            </Grid>
+            <Grid item>
+              <Button
+                variant="contained"
+                type="submit"
+                startIcon={<IconDatabase />}
+              >
+                {isRegister ? 'Register' : 'Login'}
+              </Button>
+            </Grid>
+          </Grid>
+        </form>
+        <a href="/auth42">
+          <Image src="/images/ico-42-logo.jpg" width={50} height={50} />
+        </a>
+        <br></br>
+        <a href="/google">
+          <Image src="/images/ico-google-logo-96.png" width={50} height={50} />
+        </a>
+      </Grid>
     </Layout>
   );
 };

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -42,6 +42,7 @@ const Home: NextPage = () => {
     formState: { errors },
     handleSubmit,
     clearErrors,
+    reset,
   } = useForm<AuthForm>({
     mode: 'onSubmit',
     resolver: yupResolver(schema),
@@ -69,6 +70,7 @@ const Home: NextPage = () => {
       }
     } catch (e) {
       if (axios.isAxiosError(e) && e.response && e.response.data) {
+        reset();
         const message = (e.response.data as AxiosErrorResponse).message;
         setError(message);
       }

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -10,7 +10,7 @@ import GppGoodIcon from '@mui/icons-material/GppGood';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { Layout } from '../components/Layout';
-import { AuthForm } from '../types';
+import { AuthForm, AxiosErrorResponse } from '../types';
 import {
   Grid,
   IconButton,
@@ -69,7 +69,8 @@ const Home: NextPage = () => {
       }
     } catch (e) {
       if (axios.isAxiosError(e) && e.response && e.response.data) {
-        setError(e.message);
+        const message = (e.response.data as AxiosErrorResponse).message;
+        setError(message);
       }
     }
   };
@@ -81,7 +82,7 @@ const Home: NextPage = () => {
         justifyContent="center"
         direction="column"
         alignItems="center"
-        xs={3.5}
+        sx={{ width: 360 }}
       >
         <GppGoodIcon color="primary" sx={{ width: 100, height: 100 }} />
         {error && (
@@ -91,19 +92,21 @@ const Home: NextPage = () => {
           </Alert>
         )}
         <form onSubmit={handleSubmit(onSubmit) as VoidFunction}>
+          {/* [TODO] remove email */}
           <Controller
             name="email"
             control={control}
             render={({ field }) => (
               <TextField
-                {...field}
+                required
                 placeholder="example@gmail.com"
                 fullWidth
                 size="small"
-                sx={{ mt: 2 }}
+                sx={{ my: 2 }}
                 label="Email"
                 error={errors.email ? true : false}
                 helperText={errors.email?.message}
+                {...field}
               />
             )}
           />
@@ -112,6 +115,7 @@ const Home: NextPage = () => {
             control={control}
             render={({ field }) => (
               <TextField
+                required
                 label="Password"
                 type={showPassword ? 'text' : 'password'}
                 error={errors.password ? true : false}
@@ -139,7 +143,7 @@ const Home: NextPage = () => {
                   ),
                 }}
                 size="small"
-                sx={{ mt: 4 }}
+                sx={{ my: 1 }}
                 fullWidth
                 {...field}
               />
@@ -151,13 +155,14 @@ const Home: NextPage = () => {
               control={control}
               render={({ field }) => (
                 <TextField
-                  {...field}
+                  required
                   fullWidth
                   size="small"
-                  sx={{ my: 2 }}
+                  sx={{ mb: 2 }}
                   label="Username"
                   error={errors.username ? true : false}
                   helperText={errors.username?.message}
+                  {...field}
                 />
               )}
             />

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -20,6 +20,7 @@ import {
   Alert,
   Button,
   AlertTitle,
+  Typography,
 } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
@@ -34,7 +35,7 @@ const schema = Yup.object().shape({
 const Home: NextPage = () => {
   const router = useRouter();
   const [isRegister, setIsRegister] = useState(false);
-  const [error, setError] = useState('');
+  const [error, setError] = useState<string[]>([]);
   const [showPassword, setShowPassword] = useState(false);
 
   const {
@@ -49,6 +50,7 @@ const Home: NextPage = () => {
     defaultValues: {
       email: '',
       password: '',
+      username: '',
     },
   });
   const onSubmit: SubmitHandler<AuthForm> = async (data: AuthForm) => {
@@ -71,8 +73,9 @@ const Home: NextPage = () => {
     } catch (e) {
       if (axios.isAxiosError(e) && e.response && e.response.data) {
         reset();
-        const message = (e.response.data as AxiosErrorResponse).message;
-        setError(message);
+        const messages = (e.response.data as AxiosErrorResponse).message;
+        if (Array.isArray(messages)) setError(messages);
+        else setError([messages]);
       }
     }
   };
@@ -87,10 +90,16 @@ const Home: NextPage = () => {
         sx={{ width: 360 }}
       >
         <GppGoodIcon color="primary" sx={{ width: 100, height: 100 }} />
-        {error && (
+        {error.length !== 0 && (
           <Alert severity="error">
-            <AlertTitle>Authorization Error</AlertTitle>
-            {error}
+            <>
+              <AlertTitle>Authorization Error</AlertTitle>
+              {error.map((e, i) => (
+                <Typography variant="body2" key={i}>
+                  {e}
+                </Typography>
+              ))}
+            </>
           </Alert>
         )}
         <form onSubmit={handleSubmit(onSubmit) as VoidFunction}>
@@ -174,7 +183,7 @@ const Home: NextPage = () => {
                 variant="body2"
                 onClick={() => {
                   clearErrors();
-                  setError('');
+                  setError([]);
                   setIsRegister(!isRegister);
                 }}
               >
@@ -188,6 +197,9 @@ const Home: NextPage = () => {
                 variant="contained"
                 type="submit"
                 startIcon={<IconDatabase />}
+                onClick={() => {
+                  setError([]);
+                }}
               >
                 {isRegister ? 'Register' : 'Login'}
               </Button>

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -6,6 +6,6 @@ export type AuthForm = {
 
 export type AxiosErrorResponse = {
   statusCode: number;
-  message: string;
+  message: string[] | string;
   error: string;
 };

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -1,4 +1,5 @@
 export type AuthForm = {
   email: string;
   password: string;
+  username?: string;
 };

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -3,3 +3,9 @@ export type AuthForm = {
   password: string;
   username?: string;
 };
+
+export type AxiosErrorResponse = {
+  statusCode: number;
+  message: string;
+  error: string;
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -252,6 +252,11 @@
   resolved "https://registry.yarnpkg.com/@heroicons/react/-/react-1.0.6.tgz#35dd26987228b39ef2316db3b1245c42eb19e324"
   integrity sha512-JJCXydOFWMDpCP4q13iEplA503MQO3xLoZiKum+955ZCtHINWnx26CUxVxxFQu/uLb4LW3ge15ZpzIkXKkJ8oQ==
 
+"@hookform/resolvers@^2.9.10":
+  version "2.9.10"
+  resolved "https://registry.yarnpkg.com/@hookform/resolvers/-/resolvers-2.9.10.tgz#e7e88942ee34e97b7bc937b0be4694194c9cd420"
+  integrity sha512-JIL1DgJIlH9yuxcNGtyhsWX/PgNltz+5Gr6+8SX9fhXc/hPbEIk6wPI82nhgvp3uUb6ZfAM5mqg/x7KR7NAb+A==
+
 "@humanwhocodes/config-array@^0.11.6":
   version "0.11.6"
   resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.6.tgz#6a51d603a3aaf8d4cf45b42b3f2ac9318a4adc4b"
@@ -3168,6 +3173,11 @@ react-dom@18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
+
+react-hook-form@^7.39.4:
+  version "7.39.4"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.39.4.tgz#7d9edf4e778a0cec4383f0119cd0699e3826a14a"
+  integrity sha512-B0e78r9kR9L2M4A4AXGbHoA/vyv34sB/n8QWJAw33TFz8f5t9helBbYAeqnbvcQf1EYzJxKX/bGQQh9K+evCyQ==
 
 react-is@^16.13.1, react-is@^16.7.0:
   version "16.13.1"


### PR DESCRIPTION
* resolve #94

## 概要

ユーザ登録時に重複しないユーザ名の登録フォームを追加しました。

## 確認方法

* ログイン画面にて新しいユーザを作る際に、ユーザ名も入力して`prisma studio`やホーム画面の表示を見ることで正しく登録がなされることを確認する
* 再度、登録する際にユーザ名が重複しているとエラーが出ることを確認する

## 今後の実装方針

* emailは現状、ログイン後全く必要ないデータなのでユーザ名+パスワードでログインができるようにし、emailは消去する。
* 42ログイン後のユーザ名登録の実装。

ちなみに、今のところ`username`がなくてもフロントエンドのvalidatorは通ります、(後でemail消すときに修正します。)
