### PR TITLE
OAuth認証からカスタム認証と同じ流れでログイン

### DIFF
--- a/frontend/components/common/MenuButton.tsx
+++ b/frontend/components/common/MenuButton.tsx
@@ -3,14 +3,12 @@ import MenuIcon from '@mui/icons-material/Menu';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { useState } from 'react';
-import { useRouter } from 'next/router';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import Link from 'next/link';
-import { signOut, useSession } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 
 export const MenuButton = () => {
-  const { data: session } = useSession();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const open = Boolean(anchorEl);
   const handleClick = (event: React.MouseEvent<HTMLButtonElement>) => {
@@ -19,18 +17,13 @@ export const MenuButton = () => {
   const handleClose = () => {
     setAnchorEl(null);
   };
-  const router = useRouter();
   const queryClient = useQueryClient();
   const logout = () => {
-    if (session) {
-      void signOut();
-    } else {
-      queryClient.removeQueries(['user']);
-      void axios.post(
-        `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-      );
-      void router.push('/');
-    }
+    queryClient.removeQueries(['user']);
+    void axios.post(`${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`);
+    void signOut({
+      callbackUrl: 'http://localhost:3000/',
+    });
   };
 
   return (

--- a/frontend/components/common/MenuButton.tsx
+++ b/frontend/components/common/MenuButton.tsx
@@ -6,7 +6,8 @@ import { useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import axios from 'axios';
 import Link from 'next/link';
-import { signOut } from 'next-auth/react';
+import { signOut, useSession } from 'next-auth/react';
+import { useRouter } from 'next/router';
 
 export const MenuButton = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -18,12 +19,17 @@ export const MenuButton = () => {
     setAnchorEl(null);
   };
   const queryClient = useQueryClient();
+  const { data: session } = useSession();
+  const router = useRouter();
+
   const logout = () => {
     queryClient.removeQueries(['user']);
     void axios.post(`${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`);
-    void signOut({
-      callbackUrl: 'http://localhost:3000/',
-    });
+    if (session) {
+      void signOut();
+    } else {
+      void router.push('/');
+    }
   };
 
   return (

--- a/frontend/pages/_app.tsx
+++ b/frontend/pages/_app.tsx
@@ -3,7 +3,6 @@
 import '../styles/globals.css';
 import { useEffect } from 'react';
 import type { AppProps } from 'next/app';
-import { MantineProvider } from '@mantine/core';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import axios from 'axios';
@@ -29,8 +28,10 @@ function MyApp({
   Component,
   pageProps: { session, ...pageProps },
 }: AppProps<{ session: Session }>) {
-  axios.defaults.withCredentials = true;
+  axios.defaults.withCredentials = true; // Cookieのやりとりする時に必要
   useEffect(() => {
+    // ロードされた時にCsrfトークンを取得するのでここで定義
+    // ヘッダに自動的に付与される
     const getCsrfToken = async () => {
       if (process.env.NEXT_PUBLIC_API_URL) {
         const { data } = await axios.get<Csrf>(
@@ -44,18 +45,9 @@ function MyApp({
 
   return (
     <QueryClientProvider client={queryClient}>
-      <MantineProvider
-        withGlobalStyles
-        withNormalizeCSS
-        theme={{
-          // colorScheme: 'dark',
-          fontFamily: 'Verdana, sans-serif',
-        }}
-      >
-        <SessionProvider session={session}>
-          <Component {...pageProps} />
-        </SessionProvider>
-      </MantineProvider>
+      <SessionProvider session={session}>
+        <Component {...pageProps} />
+      </SessionProvider>
       <ReactQueryDevtools />
     </QueryClientProvider>
   );

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -16,55 +16,18 @@ export default NextAuth({
     // ...add more providers here
   ],
   callbacks: {
-    signIn({}) {
-      // async signIn({ user, account, profile, email, credentials }) {
+    //    signIn({, account, profile, email, credentials}) {
+    signIn() {
       // サインインした時に実施したい処理
-      console.log('signIn');
-      // if (process.env.NEXT_PUBLIC_API_URL) {
-      //   try {
-      //     console.log('[TRY] login');
-      //     const url_login = `${process.env.NEXT_PUBLIC_API_URL}/auth/login`;
-      //     await axios.post(url_login, {
-      //       email: profile?.email,
-      //       password: profile?.name,
-      //     });
-      //     console.log('[SUCCESS] login');
-      //   } catch (e) {
-      //     //未登録なのでsignupする。
-      //     console.log('[FAILURE] login and do signup');
-      //     try {
-      //       await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth/signup`, {
-      //         email: profile?.email,
-      //         password: profile?.name,
-      //       });
-      //       console.log('[SUCCESS] signup');
-      //     } catch (e) {
-      //       console.log('[FAILURE] signup');
-      //     }
-      //   }
-
-      //   return true;
-      // }
-
       return true;
     },
     jwt({ token, account }) {
       // async jwt({ token, user, account, profile, isNewUser }) {
-      console.log('jwt');
       if (account?.accessToken) {
         token.accessToken = account.accessToken;
       }
 
       return token;
     },
-    // session({ session, token }) {
-    //   // async session({ session, user, token }) {
-    //   console.log('session');
-    //   // console.log(session);
-    //   // sessionオブジェクトに情報を追加したい場合
-    //   session.accessToken = token.accessToken;
-
-    //   return session;
-    // },
   },
 });

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -3,24 +3,10 @@ import Link from 'next/link';
 import { Stack, Button, Typography } from '@mui/material';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Header } from 'components/common/Header';
-import { signOut } from 'next-auth/react';
 import { Layout } from 'components/common/Layout';
-import axios from 'axios';
-import { LogoutIcon } from '@heroicons/react/solid';
-import { useQueryClient } from '@tanstack/react-query';
 
 const Dashboard: NextPage = () => {
   const { data: user } = useQueryUser();
-  const queryClient = useQueryClient();
-  const logout = async () => {
-    queryClient.removeQueries(['user']);
-    if (process.env.NEXT_PUBLIC_API_URL) {
-      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth/logout`);
-      void signOut({
-        callbackUrl: 'http://localhost:3000/',
-      });
-    }
-  };
 
   if (user === undefined) return <></>;
 
@@ -39,13 +25,6 @@ const Dashboard: NextPage = () => {
           <Button variant="contained">Friend</Button>
         </Link>
       </Stack>
-      <p>Sign out for mail login</p>
-      <LogoutIcon
-        className="mb-6 h-6 w-6 cursor-pointer text-blue-500"
-        onClick={() => {
-          void logout();
-        }}
-      />
     </Layout>
   );
 };

--- a/frontend/pages/dashboard.tsx
+++ b/frontend/pages/dashboard.tsx
@@ -3,14 +3,24 @@ import Link from 'next/link';
 import { Stack, Button, Typography } from '@mui/material';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Header } from 'components/common/Header';
-import { useSession } from 'next-auth/react';
+import { signOut } from 'next-auth/react';
 import { Layout } from 'components/common/Layout';
+import axios from 'axios';
+import { LogoutIcon } from '@heroicons/react/solid';
+import { useQueryClient } from '@tanstack/react-query';
 
 const Dashboard: NextPage = () => {
   const { data: user } = useQueryUser();
-  const { data: session } = useSession();
-
-  console.log(session?.user);
+  const queryClient = useQueryClient();
+  const logout = async () => {
+    queryClient.removeQueries(['user']);
+    if (process.env.NEXT_PUBLIC_API_URL) {
+      await axios.post(`${process.env.NEXT_PUBLIC_API_URL}/auth/logout`);
+      void signOut({
+        callbackUrl: 'http://localhost:3000/',
+      });
+    }
+  };
 
   if (user === undefined) return <></>;
 
@@ -29,6 +39,13 @@ const Dashboard: NextPage = () => {
           <Button variant="contained">Friend</Button>
         </Link>
       </Stack>
+      <p>Sign out for mail login</p>
+      <LogoutIcon
+        className="mb-6 h-6 w-6 cursor-pointer text-blue-500"
+        onClick={() => {
+          void logout();
+        }}
+      />
     </Layout>
   );
 };

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -24,8 +24,9 @@ import {
 } from '@mui/material';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
-import { signIn, signOut, useSession } from 'next-auth/react';
+import { signIn, useSession } from 'next-auth/react';
 
+// username, passwordのvalidation
 const schema = Yup.object().shape({
   username: Yup.string().required('No username provided'),
   password: Yup.string()
@@ -36,6 +37,7 @@ const schema = Yup.object().shape({
 const Home: NextPage = () => {
   const router = useRouter();
   const [isRegister, setIsRegister] = useState(false);
+  const [tryLogin, setTryLogin] = useState(false);
   const [error, setError] = useState<string[]>([]);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -53,7 +55,7 @@ const Home: NextPage = () => {
       username: '',
     },
   });
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
 
   const onSubmit: SubmitHandler<AuthForm> = async (data: AuthForm) => {
     try {
@@ -81,53 +83,51 @@ const Home: NextPage = () => {
     }
   };
 
-  // const oauthLogin = async () => {
-  //   try {
-  //     if (process.env.NEXT_PUBLIC_API_URL) {
-  //       try {
-  //         form.reset();
-  //         console.log(session.user?.name);
-  //         console.log(session.user?.email);
-  //         await router.push('/dashboard');
-  //       } catch (e) {
-  //         if (axios.isAxiosError(e) && e.response && e.response.data) {
-  //           setError(e.message);
-  //         }
-  //       }
-  //     }
-  //   } catch (e) {
-  //     if (axios.isAxiosError(e) && e.response && e.response.data) {
-  //       setError(e.message);
-  //     }
-  //   }
-  //   await router.push('/dashboard');
-  // };
+  const oauthLogin = async () => {
+    if (process.env.NEXT_PUBLIC_API_URL) {
+      try {
+        reset();
+        const url_signup = `${process.env.NEXT_PUBLIC_API_URL}/auth/login`;
+        await axios.post(url_signup, {
+          username: session?.user?.email,
+          password: session?.user?.name,
+        });
+        await router.push('/dashboard');
+      } catch (e) {
+        try {
+          const url_signup = `${process.env.NEXT_PUBLIC_API_URL}/auth/signup`;
+          await axios.post(url_signup, {
+            username: session?.user?.email,
+            password: session?.user?.name,
+          });
+          await router.push('/dashboard');
+        } catch (e) {
+          console.log('[FAILURE] oauth signup: catch');
+          if (axios.isAxiosError(e) && e.response && e.response.data) {
+            reset();
+            const messages = (e.response.data as AxiosErrorResponse).message;
+            if (Array.isArray(messages)) setError(messages);
+            else setError([messages]);
+          }
+        }
+      }
+    }
+  };
 
-  if (session) {
-    // ここのconsoleはブラウザに表示
-    console.log(session.user);
+  if (status === 'loading') {
+    return <p>Loading...</p>;
+  }
 
-    // oauthLogin();
-    if (session.user === undefined) {
-      return <p>session.user is undefined</p>;
+  if (status === 'authenticated') {
+    if (tryLogin == false) {
+      setTryLogin(true);
+      console.log('call oauthLogin.');
+      void (async () => {
+        await oauthLogin();
+      })();
     }
 
-    return (
-      <>
-        Signed in as <img src={session.user.image ?? ''} width="50px" />
-        {session.user.name} <br />
-        Mail: {session.user.email} <br />
-        <button
-          onClick={() => {
-            void (async () => {
-              await signOut();
-            })();
-          }}
-        >
-          Sign out
-        </button>
-      </>
-    );
+    return <p>Now Login...</p>;
   }
 
   return (

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -85,10 +85,13 @@ const Home: NextPage = () => {
 
   const oauthLogin = async () => {
     if (process.env.NEXT_PUBLIC_API_URL) {
+      if (session?.user === null) {
+        return;
+      }
       try {
         reset();
-        const url_signup = `${process.env.NEXT_PUBLIC_API_URL}/auth/login`;
-        await axios.post(url_signup, {
+        const url_login = `${process.env.NEXT_PUBLIC_API_URL}/auth/login`;
+        await axios.post(url_login, {
           username: session?.user?.email,
           password: session?.user?.name,
         });


### PR DESCRIPTION
## 変更の概要

*  42やGoogleアカウント（OAuth経由）でログインした場合も、今までのメールログインと同じ流れでSignUp->LogInが完了した状態になる

## なぜこの変更をするのか

* 今までは、カスタムのログインと、OAuthからのログインで経路が分かれていたため、同じ流れになるようにした。
* usernameはメールアドレス、passwordは名前、を入力した状態と同じになる

## 影響範囲

* OAuthからのログインでもdashboardに遷移し、chatやgameができる状態になる
* HeaderのメニューからのLoginにも対応

## 確認方法

* DBへの追加などはなし
* frontend: yarn build && yarn run dev
* backend: yarn build && yarn start:dev

## 確認してもらいたいこと
* 42ログインできる方は、ご自身のアカウントからログインしてdashboard以降が使えるか
* その他、各ページの動作に影響がないか

## 課題

* OAuthで認証した場合、usernameはメールアドレス、passwordは名前（shogo kohrakuなど）としているため、手動で入力してもログインできる。認証方式もDBに情報を残すことで回避はできるが、課題必須でなければ優先度は下げようと思ってます。

## 備考

* 直接 localhost:3000/chat などにアクセスした時のログインページへのredirectは従来通り、ReactQueryの仕組みを利用しています。NextAuthでも同様にsessionを管理できますが、pages/index.ts内のみで利用しており、他のページでは意識しないで問題ないです。
* MantineのUIは使用しないとのことで、_app.tsxからもMantineProviderを削除しておきました。