### PR TITLE
Settingページの実装と細かい諸々

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -8,3 +8,4 @@
 
 DATABASE_URL="postgresql://user:pass@localhost:5434/dbname/?schema=public"
 JWT_SECRET='mSSS9Zrd'
+AVATAR_IMAGE_DIR="./uploads/avatarImages"

--- a/backend/package.json
+++ b/backend/package.json
@@ -34,6 +34,7 @@
     "@nestjs/platform-socket.io": "^9.1.6",
     "@nestjs/websockets": "^9.1.6",
     "@prisma/client": "4.5.0",
+    "@types/multer": "^1.4.7",
     "bcrypt": "^5.1.0",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.13.2",
@@ -43,7 +44,8 @@
     "passport-jwt": "^4.0.0",
     "reflect-metadata": "^0.1.13",
     "rimraf": "^3.0.2",
-    "rxjs": "^7.2.0"
+    "rxjs": "^7.2.0",
+    "uuid": "^9.0.0"
   },
   "devDependencies": {
     "@nestjs/cli": "^9.0.0",
@@ -65,6 +67,7 @@
     "@types/socket.io": "^3.0.2",
     "@types/source-map-support": "^0.5.6",
     "@types/supertest": "^2.0.11",
+    "@types/uuid": "^8.3.4",
     "@typescript-eslint/eslint-plugin": "^5.40.1",
     "@typescript-eslint/parser": "^5.40.1",
     "eslint": "^8.26.0",

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -14,7 +14,7 @@ model User {
   name            String            @unique
   hashedPassword  String?
   point           Int               @default(1000)
-  avatarPath     String?
+  avatarPath      String?
   chatroomOwners  Chatroom[]
   chatroomAdmins  ChatroomAdmin[]
   chatroomMembers ChatroomMembers[]

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -62,7 +62,6 @@ export class AuthService {
     };
     const secret = this.config.get<string>('JWT_SECRET');
     const token = await this.jwt.signAsync(payload, {
-      expiresIn: '5m',
       secret: secret,
     });
 

--- a/backend/src/user/dto/update-avatar-path.dto.ts
+++ b/backend/src/user/dto/update-avatar-path.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateAvatarPathDto {
+  @IsString()
+  @IsNotEmpty()
+  avatarPath: string;
+}

--- a/backend/src/user/dto/update-avatar.dto.ts
+++ b/backend/src/user/dto/update-avatar.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString } from 'class-validator';
 
-export class UpdateAvatarPathDto {
+export class UpdateAvatarDto {
   @IsString()
   @IsNotEmpty()
   avatarPath: string;

--- a/backend/src/user/dto/update-name.dto.ts
+++ b/backend/src/user/dto/update-name.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsString } from 'class-validator';
+
+export class UpdateNameDto {
+  @IsString()
+  @IsNotEmpty()
+  name: string;
+}

--- a/backend/src/user/dto/update-user.dto.ts
+++ b/backend/src/user/dto/update-user.dto.ts
@@ -1,7 +1,0 @@
-import { IsOptional, IsString } from 'class-validator';
-
-export class UpdateUserDto {
-  @IsString()
-  @IsOptional()
-  name?: string;
-}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -10,7 +10,7 @@ import {
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
 import { UserService } from './user.service';
-import { UpdateUserDto } from './dto/update-user.dto';
+import { UpdateNameDto } from './dto/update-name.dto';
 import { User } from '@prisma/client';
 import { UpdatePointDto } from './dto/update-point.dto';
 
@@ -33,17 +33,11 @@ export class UserController {
     return this.userService.updatePoint(Number(id), dto);
   }
 
-  @Patch()
-  updateUser(
-    @Req() req: Request,
-    @Body() dto: UpdateUserDto,
+  @Patch('name/:id')
+  updateName(
+    @Param('id') id: string,
+    @Body() dto: UpdateNameDto,
   ): Promise<Omit<User, 'hashedPassword'>> {
-    // for eslint
-    interface RequestUser {
-      id: number;
-    }
-    const req_user: RequestUser = req.user;
-
-    return this.userService.updateUser(req_user.id, dto);
+    return this.userService.updateName(Number(id), dto);
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -6,7 +6,6 @@ import {
   Patch,
   Post,
   Req,
-  StreamableFile,
   UploadedFile,
   UseGuards,
   UseInterceptors,
@@ -21,14 +20,13 @@ import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
 import { v4 as uuidv4 } from 'uuid';
 import * as path from 'path';
-import { createReadStream } from 'fs';
 
 const storage = {
   storage: diskStorage({
     destination: './uploads/avatarImages',
     filename: (req, file, cb) => {
       // remove unnecessary spaces from file name and
-      // append uuid key to the file name to prevent file name confilicts
+      // append the file name with uuid to prevent file name confilicts
       const filename: string =
         path.parse(file.originalname).name.replace(/\s/g, '') + uuidv4();
       const extension: string = path.parse(file.originalname).ext;
@@ -70,22 +68,21 @@ export class UserController {
     @UploadedFile() file: Express.Multer.File,
     @Param('id') id: string,
   ) {
-    console.log(file);
-
-    return this.userService.updateAvatarPath(Number(id), {
+    return this.userService.updateAvatar(Number(id), {
       avatarPath: file.filename,
     });
   }
 
   @Get(':imageUrl')
   getAvatarImage(@Param('imageUrl') imageUrl: string) {
-    const filePath = path.join(
-      process.cwd(),
-      'uploads/avatarImages/',
-      imageUrl,
-    );
-    const file = createReadStream(filePath);
+    return this.userService.getAvatarImage(imageUrl);
+  }
 
-    return new StreamableFile(file);
+  @Patch('avatar/:id/:avatarPath')
+  deleteAvatar(
+    @Param('id') id: string,
+    @Param('avatarPath') avatarPath: string,
+  ) {
+    return this.userService.deleteAvatar(Number(id), avatarPath);
   }
 }

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -24,9 +24,9 @@ import * as path from 'path';
 // FileInterceptorにわたすオプションを設定。
 // destination: ファイルの保存先。フォルダが無い場合には、バックエンドを起動したタイミングでフォルダが生成される
 // filename: 保存されるファイルのファイル名を修正するためのロジックを設定できる。何も設定しないと、拡張子もつかないランダムなファイル名が勝手につけられる
-const storage = (destinationPath: string) => ({
+const storage = {
   storage: diskStorage({
-    destination: destinationPath,
+    destination: process.env.AVATAR_IMAGE_DIR,
     filename: (req, file, cb) => {
       // ファイル名に空白があれば削除して、末尾にuuidを追加したあとに拡張子を付与することで
       // 複数ユーザーからimage.jpgみたいなありがちな名前のファイルがアップロードされた場合
@@ -38,7 +38,7 @@ const storage = (destinationPath: string) => ({
       cb(null, `${filename}${extension}`);
     },
   }),
-});
+};
 
 @UseGuards(AuthGuard('jwt'))
 @Controller('user')
@@ -67,14 +67,11 @@ export class UserController {
     return this.userService.updateName(Number(id), dto);
   }
 
-  // storageの部分は、本当は下記のような形で.envからパスを引っ張ってきたいのだが、thisの使い方をちゃんと理解しきれていないせいで
-  // うまく実装できていないです。これ、どうやったらいいか、どなたかわかれば教えてほしいです。
-  // storage(this.config.get<string>('AVATAR_IMAGE_DIR')),
   @Post('avatar/:id')
   @UseInterceptors(
     FileInterceptor(
       'avatar', // ここの'avatar'はフロントエンドでformData.appendに渡した第一引数のnameと対応
-      storage('./uploads/avatarImages'),
+      storage,
     ),
   )
   uploadAvatar(

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
-import { UpdateUserDto } from './dto/update-user.dto';
+import { UpdateNameDto } from './dto/update-name.dto';
 import { User } from '@prisma/client';
 import { UpdatePointDto } from './dto/update-point.dto';
 
@@ -19,9 +19,9 @@ export class UserService {
     return user;
   }
 
-  async updateUser(
+  async updateName(
     userId: number,
-    dto: UpdateUserDto,
+    dto: UpdateNameDto,
   ): Promise<Omit<User, 'hashedPassword'>> {
     const user = await this.prisma.user.update({
       where: {

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -3,6 +3,7 @@ import { PrismaService } from '../prisma/prisma.service';
 import { UpdateNameDto } from './dto/update-name.dto';
 import { User } from '@prisma/client';
 import { UpdatePointDto } from './dto/update-point.dto';
+import { UpdateAvatarPathDto } from './dto/update-avatar-path.dto';
 
 @Injectable()
 export class UserService {
@@ -39,6 +40,23 @@ export class UserService {
   async updatePoint(
     userId: number,
     dto: UpdatePointDto,
+  ): Promise<Omit<User, 'hashedPassword'>> {
+    const user = await this.prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        ...dto,
+      },
+    });
+    delete user.hashedPassword;
+
+    return user;
+  }
+
+  async updateAvatarPath(
+    userId: number,
+    dto: UpdateAvatarPathDto,
   ): Promise<Omit<User, 'hashedPassword'>> {
     const user = await this.prisma.user.update({
       where: {

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -1,13 +1,17 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, StreamableFile } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateNameDto } from './dto/update-name.dto';
 import { User } from '@prisma/client';
 import { UpdatePointDto } from './dto/update-point.dto';
-import { UpdateAvatarPathDto } from './dto/update-avatar-path.dto';
+import { UpdateAvatarDto } from './dto/update-avatar.dto';
+import { createReadStream, unlink } from 'node:fs';
+import * as path from 'path';
 
 @Injectable()
 export class UserService {
   constructor(private prisma: PrismaService) {}
+
+  static avatarImageDir = 'uploads/avatarImages';
 
   async findOne(userId: number): Promise<Omit<User, 'hashPassword'> | null> {
     const user = await this.prisma.user.findUnique({
@@ -54,9 +58,47 @@ export class UserService {
     return user;
   }
 
-  async updateAvatarPath(
+  getAvatarImage(imageUrl: string): StreamableFile {
+    const filePath = path.join(
+      process.cwd(),
+      UserService.avatarImageDir,
+      imageUrl,
+    );
+    const file = createReadStream(filePath);
+
+    // StreamableFileを使うと、バックエンドのローカルにある画像をフロントエンドに送れる
+    return new StreamableFile(file);
+  }
+
+  async deleteAvatar(
     userId: number,
-    dto: UpdateAvatarPathDto,
+    avatarPath: string,
+  ): Promise<Omit<User, 'hashedPassword'>> {
+    const filePath = path.join(
+      process.cwd(),
+      UserService.avatarImageDir,
+      avatarPath,
+    );
+    unlink(filePath, (err) => {
+      if (err) throw err;
+      console.log(`${filePath} was deleted`);
+    });
+    const user = await this.prisma.user.update({
+      where: {
+        id: userId,
+      },
+      data: {
+        avatarPath: null,
+      },
+    });
+    delete user.hashedPassword;
+
+    return user;
+  }
+
+  async updateAvatar(
+    userId: number,
+    dto: UpdateAvatarDto,
   ): Promise<Omit<User, 'hashedPassword'>> {
     const user = await this.prisma.user.update({
       where: {

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -95,22 +95,8 @@ export class UserService {
       if (err) throw err;
       console.log(`${filePath} was deleted`);
     });
-    try {
-      const user = await this.prisma.user.update({
-        where: {
-          id: userId,
-        },
-        data: {
-          avatarPath: null,
-        },
-      });
-      delete user.hashedPassword;
 
-      return user;
-    } catch (error) {
-      console.log(error);
-      throw error;
-    }
+    return this.updateAvatar(userId, { avatarPath: null });
   }
 
   async updateAvatar(

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -1109,6 +1109,13 @@
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-5.1.2.tgz#07508b45797cb81ec3f273011b054cd0755eddca"
   integrity sha512-K0VQKziLUWkVKiRVrx4a40iPaxTUefQmjtkQofBkYRcoaaL/8rhwDWww9qWbrgicNOgnpIsMxyNIUM4+n6dUIA==
 
+"@types/multer@^1.4.7":
+  version "1.4.7"
+  resolved "https://registry.yarnpkg.com/@types/multer/-/multer-1.4.7.tgz#89cf03547c28c7bbcc726f029e2a76a7232cc79e"
+  integrity sha512-/SNsDidUFCvqqcWDwxv2feww/yqhNeTRL5CVoL3jU4Goc4kKEL10T7Eye65ZqPNi4HRx8sAEX59pV1aEH7drNA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/node@*":
   version "18.11.3"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
@@ -1222,6 +1229,11 @@
   integrity sha512-X3HPWTwXRerBZS7Mo1k6vMVR1Z6zmJcDVn5O/31whe0tnjE4te6ZJSJGq1RiqHPjzPdMTfjCFogDJmwng9xHaQ==
   dependencies:
     "@types/superagent" "*"
+
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
 
 "@types/yargs-parser@*":
   version "21.0.0"
@@ -5981,7 +5993,7 @@ uuid@8.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
-uuid@9.0.0:
+uuid@9.0.0, uuid@^9.0.0:
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.0.tgz#592f550650024a38ceb0c562f2f6aa435761efb5"
   integrity sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==

--- a/frontend/components/common/MenuButton.tsx
+++ b/frontend/components/common/MenuButton.tsx
@@ -59,7 +59,9 @@ export const MenuButton = () => {
         <Link href="/profile">
           <MenuItem>Profile</MenuItem>
         </Link>
-        <MenuItem onClick={handleClose}>Setting</MenuItem>
+        <Link href="/setting">
+          <MenuItem>Setting</MenuItem>
+        </Link>
         <MenuItem onClick={logout}>Logout</MenuItem>
       </Menu>
     </div>

--- a/frontend/components/game/home/Profile.tsx
+++ b/frontend/components/game/home/Profile.tsx
@@ -7,7 +7,10 @@ import ThumbDownOffAltIcon from '@mui/icons-material/ThumbDownOffAlt';
 export const Profile = () => {
   const { data: user } = useQueryUser();
   if (user === undefined) return <></>;
-  const avatarPath = user.avatarPath !== null ? user.avatarPath : '';
+  const avatarImageUrl =
+    user.avatarPath !== null
+      ? `${process.env.NEXT_PUBLIC_API_URL as string}/user/${user.avatarPath}`
+      : '';
 
   return (
     <>
@@ -25,7 +28,7 @@ export const Profile = () => {
         >
           <Grid item>
             <Avatar
-              src={avatarPath} // Avatar can show a default avatar image when the provided path is invalid
+              src={avatarImageUrl} // Avatar can show a default avatar image when the provided path is invalid
               sx={{ width: 100, height: 100 }}
             />
           </Grid>

--- a/frontend/hooks/useMutatePoint.tsx
+++ b/frontend/hooks/useMutatePoint.tsx
@@ -1,11 +1,9 @@
-import { useRouter } from 'next/router';
 import axios, { AxiosError } from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
 export const useMutatePoint = () => {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   const updatePointMutation = useMutation<
     Omit<User, 'hashedPassword'>,
@@ -29,17 +27,9 @@ export const useMutatePoint = () => {
           queryClient.setQueryData(['user'], res);
         }
       },
-      onError: async (err: AxiosError) => {
-        if (
-          err.response &&
-          (err.response.status === 401 || err.response.status === 403)
-        ) {
-          queryClient.removeQueries(['user']);
-          await axios.post(
-            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-          );
-          await router.push('/');
-        }
+      onError: (err: AxiosError) => {
+        console.log(err);
+        throw err;
       },
     },
   );

--- a/frontend/hooks/useMutationAvatar.tsx
+++ b/frontend/hooks/useMutationAvatar.tsx
@@ -45,5 +45,46 @@ export const useMutateAvatar = () => {
     },
   );
 
-  return { updateAvatarMutation };
+  const deleteAvatarMutation = useMutation<
+    Omit<User, 'hashedPassword'>,
+    AxiosError,
+    { userId: number; avatarPath: string }
+  >(
+    // Backend側でuserIdからいちいちavatarPathを取得してくる手間を省くためにavatarPathも送信
+    async ({ userId, avatarPath }) => {
+      const { data } = await axios.patch<Omit<User, 'hashedPassword'>>(
+        `${
+          process.env.NEXT_PUBLIC_API_URL as string
+        }/user/avatar/${userId}/${avatarPath}`,
+      );
+
+      return data;
+    },
+    {
+      onSuccess: (res) => {
+        const oldUserData = queryClient.getQueryData<
+          Omit<User, 'hashedPassword'>
+        >(['user']);
+        if (oldUserData) {
+          queryClient.setQueryData(['user'], res);
+        }
+      },
+      onError: async (err: AxiosError) => {
+        console.log(err);
+        if (
+          err.response &&
+          (err.response.status === 401 || err.response.status === 403)
+        ) {
+          // [TODO] OAuthでログインした場合のログアウト処理も追加。おそらく他のuseMutation系も同じ
+          queryClient.removeQueries(['user']);
+          await axios.post(
+            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
+          );
+          await router.push('/');
+        }
+      },
+    },
+  );
+
+  return { updateAvatarMutation, deleteAvatarMutation };
 };

--- a/frontend/hooks/useMutationAvatar.tsx
+++ b/frontend/hooks/useMutationAvatar.tsx
@@ -1,11 +1,9 @@
-import { useRouter } from 'next/router';
 import axios, { AxiosError } from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
 export const useMutateAvatar = () => {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   const updateAvatarMutation = useMutation<
     Omit<User, 'hashedPassword'>,
@@ -29,18 +27,9 @@ export const useMutateAvatar = () => {
           queryClient.setQueryData(['user'], res);
         }
       },
-      onError: async (err: AxiosError) => {
+      onError: (err: AxiosError) => {
         console.log(err);
-        if (
-          err.response &&
-          (err.response.status === 401 || err.response.status === 403)
-        ) {
-          queryClient.removeQueries(['user']);
-          await axios.post(
-            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-          );
-          await router.push('/');
-        }
+        throw err;
       },
     },
   );
@@ -69,20 +58,10 @@ export const useMutateAvatar = () => {
           queryClient.setQueryData(['user'], res);
         }
       },
-      onError: async (err: AxiosError) => {
+      onError: (err: AxiosError) => {
         // [TODO] エラーがあった場合に、UI上もなにかアラートを出す
         console.log(err);
-        if (
-          err.response &&
-          (err.response.status === 401 || err.response.status === 403)
-        ) {
-          // [TODO] OAuthでログインした場合のログアウト処理も追加。おそらく他のuseMutation系も同じ
-          queryClient.removeQueries(['user']);
-          await axios.post(
-            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-          );
-          await router.push('/');
-        }
+        throw err;
       },
     },
   );

--- a/frontend/hooks/useMutationAvatar.tsx
+++ b/frontend/hooks/useMutationAvatar.tsx
@@ -1,0 +1,49 @@
+import { useRouter } from 'next/router';
+import axios, { AxiosError } from 'axios';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { User } from '@prisma/client';
+
+export const useMutateAvatar = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const updateAvatarMutation = useMutation<
+    Omit<User, 'hashedPassword'>,
+    AxiosError,
+    { userId: number; updatedAvatarFile: FormData }
+  >(
+    async ({ userId, updatedAvatarFile }) => {
+      const { data } = await axios.post<Omit<User, 'hashedPassword'>>(
+        `${process.env.NEXT_PUBLIC_API_URL as string}/user/avatar/${userId}`,
+        updatedAvatarFile,
+      );
+
+      return data;
+    },
+    {
+      onSuccess: (res) => {
+        const oldUserData = queryClient.getQueryData<
+          Omit<User, 'hashedPassword'>
+        >(['user']);
+        if (oldUserData) {
+          queryClient.setQueryData(['user'], res);
+        }
+      },
+      onError: async (err: AxiosError) => {
+        console.log(err);
+        if (
+          err.response &&
+          (err.response.status === 401 || err.response.status === 403)
+        ) {
+          queryClient.removeQueries(['user']);
+          await axios.post(
+            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
+          );
+          await router.push('/');
+        }
+      },
+    },
+  );
+
+  return { updateAvatarMutation };
+};

--- a/frontend/hooks/useMutationAvatar.tsx
+++ b/frontend/hooks/useMutationAvatar.tsx
@@ -70,6 +70,7 @@ export const useMutateAvatar = () => {
         }
       },
       onError: async (err: AxiosError) => {
+        // [TODO] エラーがあった場合に、UI上もなにかアラートを出す
         console.log(err);
         if (
           err.response &&

--- a/frontend/hooks/useMutationName.tsx
+++ b/frontend/hooks/useMutationName.tsx
@@ -30,6 +30,7 @@ export const useMutateName = () => {
         }
       },
       onError: async (err: AxiosError) => {
+        // [TODO] エラーがあった場合に、UI上もなにかアラートを出す
         console.log(err);
         if (
           err.response &&

--- a/frontend/hooks/useMutationName.tsx
+++ b/frontend/hooks/useMutationName.tsx
@@ -1,0 +1,49 @@
+import { useRouter } from 'next/router';
+import axios, { AxiosError } from 'axios';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { User } from '@prisma/client';
+
+export const useMutateName = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const updateNameMutation = useMutation<
+    Omit<User, 'hashedPassword'>,
+    AxiosError,
+    { userId: number; updatedName: string }
+  >(
+    async ({ userId, updatedName }) => {
+      const { data } = await axios.patch<Omit<User, 'hashedPassword'>>(
+        `${process.env.NEXT_PUBLIC_API_URL as string}/user/name/${userId}`,
+        { name: updatedName },
+      );
+
+      return data;
+    },
+    {
+      onSuccess: (res) => {
+        const oldUserData = queryClient.getQueryData<
+          Omit<User, 'hashedPassword'>
+        >(['user']);
+        if (oldUserData) {
+          queryClient.setQueryData(['user'], res);
+        }
+      },
+      onError: async (err: AxiosError) => {
+        console.log(err);
+        if (
+          err.response &&
+          (err.response.status === 401 || err.response.status === 403)
+        ) {
+          queryClient.removeQueries(['user']);
+          await axios.post(
+            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
+          );
+          await router.push('/');
+        }
+      },
+    },
+  );
+
+  return { updateNameMutation };
+};

--- a/frontend/hooks/useMutationName.tsx
+++ b/frontend/hooks/useMutationName.tsx
@@ -1,11 +1,9 @@
-import { useRouter } from 'next/router';
 import axios, { AxiosError } from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
 export const useMutateName = () => {
   const queryClient = useQueryClient();
-  const router = useRouter();
 
   const updateNameMutation = useMutation<
     Omit<User, 'hashedPassword'>,
@@ -29,19 +27,10 @@ export const useMutateName = () => {
           queryClient.setQueryData(['user'], res);
         }
       },
-      onError: async (err: AxiosError) => {
+      onError: (err: AxiosError) => {
         // [TODO] エラーがあった場合に、UI上もなにかアラートを出す
         console.log(err);
-        if (
-          err.response &&
-          (err.response.status === 401 || err.response.status === 403)
-        ) {
-          queryClient.removeQueries(['user']);
-          await axios.post(
-            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-          );
-          await router.push('/');
-        }
+        throw err;
       },
     },
   );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,7 +32,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "socket.io-client": "^4.5.3",
-    "yup": "^0.32.11"
+    "zod": "^3.19.1"
   },
   "devDependencies": {
     "@emotion/react": "^11.10.4",

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -3,13 +3,11 @@ import type { NextPage } from 'next';
 import { useState } from 'react';
 import { useRouter } from 'next/router';
 import axios from 'axios';
-import * as Yup from 'yup';
 import { IconDatabase } from '@tabler/icons';
 import Image from 'next/image';
 import GppGoodIcon from '@mui/icons-material/GppGood';
 import { Layout } from 'components/common/Layout';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
-import { yupResolver } from '@hookform/resolvers/yup';
 import { AuthForm, AxiosErrorResponse } from '../types';
 import {
   Grid,
@@ -25,12 +23,12 @@ import {
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import { signIn, signOut, useSession } from 'next-auth/react';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
 
-const schema = Yup.object().shape({
-  username: Yup.string().required('No username provided'),
-  password: Yup.string()
-    .required('No password provided')
-    .min(5, 'Password should be min 5 chars'),
+const schema = z.object({
+  username: z.string().min(1, { message: 'No username provided' }),
+  password: z.string().min(5, { message: 'Password should be min 5 chars' }),
 });
 
 const Home: NextPage = () => {
@@ -47,7 +45,7 @@ const Home: NextPage = () => {
     reset,
   } = useForm<AuthForm>({
     mode: 'onSubmit',
-    resolver: yupResolver(schema),
+    resolver: zodResolver(schema),
     defaultValues: {
       password: '',
       username: '',

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -1,12 +1,13 @@
 import { Avatar, Grid, Typography } from '@mui/material';
 import { Header } from 'components/common/Header';
 import { Layout } from 'components/common/Layout';
+import { Loading } from 'components/common/Loading';
 import { useQueryUser } from 'hooks/useQueryUser';
 import type { NextPage } from 'next';
 
 const Profile: NextPage = () => {
   const { data: user } = useQueryUser();
-  if (user === undefined) return <></>;
+  if (user === undefined) return <Loading />;
   const userName = user.name;
   const point = user.point;
   const avatarImageUrl =

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -6,8 +6,13 @@ import type { NextPage } from 'next';
 
 const Profile: NextPage = () => {
   const { data: user } = useQueryUser();
-  const userName = user !== undefined ? user.name : 'No name';
-  const point = user !== undefined ? user.point : 0;
+  if (user === undefined) return <></>;
+  const userName = user.name;
+  const point = user.point;
+  const avatarImageUrl =
+    user.avatarPath !== null
+      ? `${process.env.NEXT_PUBLIC_API_URL as string}/user/${user.avatarPath}`
+      : '';
 
   return (
     <Layout title="Profile">
@@ -20,7 +25,7 @@ const Profile: NextPage = () => {
         sx={{ p: 2 }}
       >
         <Grid item>
-          <Avatar sx={{ width: 150, height: 150 }} />
+          <Avatar sx={{ width: 150, height: 150 }} src={avatarImageUrl} />
         </Grid>
         <Grid item>
           <Typography gutterBottom variant="h3" component="div">

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -1,0 +1,90 @@
+import { Avatar, Grid, Button, Stack, TextField } from '@mui/material';
+import { Header } from 'components/common/Header';
+import { Layout } from 'components/common/Layout';
+import { useMutateName } from 'hooks/useMutationName';
+import { useQueryUser } from 'hooks/useQueryUser';
+import type { NextPage } from 'next';
+import { useForm, SubmitHandler } from 'react-hook-form';
+import { SettingForm } from 'types/setting';
+
+const Setting: NextPage = () => {
+  const { data: user } = useQueryUser();
+  if (user === undefined) return <></>;
+  const { register, handleSubmit } = useForm<SettingForm>({
+    mode: 'onSubmit',
+    defaultValues: {
+      username: user.name,
+    },
+  });
+  const registeredUsername = register('username');
+  const { updateNameMutation } = useMutateName();
+
+  const onSubmit: SubmitHandler<SettingForm> = (data: SettingForm) => {
+    updateNameMutation.mutate({ userId: user.id, updatedName: data.username });
+  };
+
+  return (
+    <Layout title="Setting">
+      <Header title="Setting" />
+      <form
+        // [TODO] replace type coercion if possible...
+        onSubmit={handleSubmit(onSubmit) as VoidFunction}
+      >
+        <Grid
+          container
+          alignItems="center"
+          justifyContent="center"
+          sx={{ p: 2 }}
+          spacing={5}
+        >
+          <Grid item>
+            <Avatar sx={{ width: 150, height: 150 }} />
+          </Grid>
+          <Grid item>
+            <Stack spacing={2} direction="column">
+              <Button variant="contained">Change picture</Button>
+              <Button variant="outlined">Delete picture</Button>
+            </Stack>
+          </Grid>
+        </Grid>
+        <Grid
+          container
+          alignItems="center"
+          justifyContent="center"
+          spacing={2}
+          sx={{ p: 2 }}
+        >
+          <Grid item xs={4}>
+            <TextField
+              // [TODO] replace type coercion if possible...
+              onChange={registeredUsername.onChange as unknown as VoidFunction}
+              onBlur={registeredUsername.onBlur as unknown as VoidFunction}
+              name={registeredUsername.name}
+              ref={registeredUsername.ref}
+              fullWidth
+              required
+              id="user-name"
+              label="Username"
+              defaultValue={user.name}
+            />
+          </Grid>
+        </Grid>
+        <Grid
+          container
+          alignItems="center"
+          justifyContent="center"
+          spacing={2}
+          sx={{ p: 2 }}
+        >
+          <Grid item>
+            <Button variant="contained" type="submit">
+              Update
+            </Button>
+          </Grid>
+        </Grid>
+      </form>
+    </Layout>
+  );
+};
+
+export default Setting;

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -94,6 +94,9 @@ const Setting: NextPage = () => {
                   accept="image/*"
                   type="file"
                   onChange={onChangeAvatar}
+                  onClick={(e) => {
+                    (e.target as HTMLInputElement).value = '';
+                  }}
                 />
               </Button>
               <Button

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -4,17 +4,29 @@ import { Layout } from 'components/common/Layout';
 import { useMutateName } from 'hooks/useMutationName';
 import { useQueryUser } from 'hooks/useQueryUser';
 import type { NextPage } from 'next';
-import { useForm, SubmitHandler } from 'react-hook-form';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { SettingForm } from 'types/setting';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
+
+const schema = z.object({
+  username: z.string().min(1, { message: 'Username cannot be empty' }),
+});
 
 const Setting: NextPage = () => {
   const { data: user } = useQueryUser();
   if (user === undefined) return <></>;
-  const { register, handleSubmit } = useForm<SettingForm>({
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<SettingForm>({
     mode: 'onSubmit',
     defaultValues: {
       username: user.name,
     },
+    resolver: zodResolver(schema),
   });
   const registeredUsername = register('username');
   const { updateNameMutation } = useMutateName();
@@ -55,17 +67,27 @@ const Setting: NextPage = () => {
           sx={{ p: 2 }}
         >
           <Grid item xs={4}>
-            <TextField
-              // [TODO] replace type coercion if possible...
-              onChange={registeredUsername.onChange as unknown as VoidFunction}
-              onBlur={registeredUsername.onBlur as unknown as VoidFunction}
-              name={registeredUsername.name}
-              ref={registeredUsername.ref}
-              fullWidth
-              required
-              id="user-name"
-              label="Username"
-              defaultValue={user.name}
+            <Controller
+              name="username"
+              control={control}
+              render={() => (
+                <TextField
+                  // [TODO] replace type coercion if possible...
+                  onChange={
+                    registeredUsername.onChange as unknown as VoidFunction
+                  }
+                  onBlur={registeredUsername.onBlur as unknown as VoidFunction}
+                  name={registeredUsername.name}
+                  ref={registeredUsername.ref}
+                  fullWidth
+                  required
+                  id="user-name"
+                  label="Username"
+                  defaultValue={user.name}
+                  error={errors.username ? true : false}
+                  helperText={errors.username?.message}
+                />
+              )}
             />
           </Grid>
         </Grid>

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -24,9 +24,6 @@ const Setting: NextPage = () => {
     formState: { errors },
   } = useForm<SettingForm>({
     mode: 'onSubmit',
-    defaultValues: {
-      username: user !== undefined ? user.name : '',
-    },
     resolver: zodResolver(schema),
   });
   const { updateNameMutation } = useMutateName();

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -54,7 +54,7 @@ const Setting: NextPage = () => {
     }
     const newAvatarFile = event.target.files[0];
     const formData = new FormData();
-    formData.append('avatar', newAvatarFile);
+    formData.append('avatar', newAvatarFile); // この第一引数のnameを使ってバックエンドのFileInterceptorはファイル名を取り出す
     updateAvatarMutation.mutate({
       userId: user.id,
       updatedAvatarFile: formData,

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -8,6 +8,8 @@ import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { SettingForm } from 'types/setting';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
+import { ChangeEventHandler } from 'react';
+import { useMutateAvatar } from 'hooks/useMutationAvatar';
 
 const schema = z.object({
   username: z.string().min(1, { message: 'Username cannot be empty' }),
@@ -30,9 +32,21 @@ const Setting: NextPage = () => {
   });
   const registeredUsername = register('username');
   const { updateNameMutation } = useMutateName();
+  const { updateAvatarMutation } = useMutateAvatar();
 
   const onSubmit: SubmitHandler<SettingForm> = (data: SettingForm) => {
     updateNameMutation.mutate({ userId: user.id, updatedName: data.username });
+  };
+
+  const onChangeAvatar: ChangeEventHandler<HTMLInputElement> = (event) => {
+    if (event.target.files === null) return;
+    const newAvatarFile = event.target.files[0];
+    const formData = new FormData();
+    formData.append('avatar', newAvatarFile);
+    updateAvatarMutation.mutate({
+      userId: user.id,
+      updatedAvatarFile: formData,
+    });
   };
 
   return (
@@ -54,8 +68,16 @@ const Setting: NextPage = () => {
           </Grid>
           <Grid item>
             <Stack spacing={2} direction="column">
-              <Button variant="contained">Change picture</Button>
-              <Button variant="outlined">Delete picture</Button>
+              <Button variant="contained" component="label">
+                Change avatar
+                <input
+                  hidden
+                  accept="image/*"
+                  type="file"
+                  onChange={onChangeAvatar}
+                />
+              </Button>
+              <Button variant="outlined">Delete avatar</Button>
             </Stack>
           </Grid>
         </Grid>
@@ -100,7 +122,7 @@ const Setting: NextPage = () => {
         >
           <Grid item>
             <Button variant="contained" type="submit">
-              Update
+              Update username
             </Button>
           </Grid>
         </Grid>

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -10,6 +10,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { ChangeEventHandler } from 'react';
 import { useMutateAvatar } from 'hooks/useMutationAvatar';
+import { Loading } from 'components/common/Loading';
 
 const schema = z.object({
   username: z.string().min(1, { message: 'Username cannot be empty' }),
@@ -29,7 +30,7 @@ const Setting: NextPage = () => {
   const { updateNameMutation } = useMutateName();
   const { updateAvatarMutation, deleteAvatarMutation } = useMutateAvatar();
 
-  if (user === undefined) return <></>;
+  if (user === undefined) return <Loading />;
   const registeredUsername = register('username');
 
   const avatarImageUrl =

--- a/frontend/types/setting.ts
+++ b/frontend/types/setting.ts
@@ -1,0 +1,3 @@
+export type SettingForm = {
+  username: string;
+};

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -69,7 +69,7 @@
   dependencies:
     regenerator-runtime "^0.13.10"
 
-"@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3":
+"@babel/runtime@^7.16.3":
   version "7.20.1"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.1.tgz#1148bb33ab252b165a06698fde7576092a78b4a9"
   integrity sha512-mrzLkl6U9YLF8qpqI7TB82PESyEGjm/0Ly91jG575eVxMMlb8fYfOXFZIJ8XfLrJZQbm7dlKry2bJmXBUEkdFg==
@@ -732,11 +732,6 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==
-
-"@types/lodash@^4.14.175":
-  version "4.14.188"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.188.tgz#e4990c4c81f7c9b00c5ff8eae389c10f27980da5"
-  integrity sha512-zmEmF5OIM3rb7SbLCFYoQhO4dGt2FRM9AMkxvA3LaADOF1n8in/zGJlWji9fmafLoNyz+FoL6FE0SLtGIArD7w==
 
 "@types/node@18.11.3", "@types/node@>=10.0.0":
   version "18.11.3"
@@ -2635,20 +2630,10 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash-es@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
-  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
-
 lodash.merge@^4.6.2:
   version "4.6.2"
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
-
-lodash@^4.17.21:
-  version "4.17.21"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
-  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 log-symbols@^4.1.0:
   version "4.1.0"
@@ -2763,11 +2748,6 @@ multipipe@^1.0.2:
   dependencies:
     duplexer2 "^0.1.2"
     object-assign "^4.1.0"
-
-nanoclone@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/nanoclone/-/nanoclone-0.2.1.tgz#dd4090f8f1a110d26bb32c49ed2f5b9235209ed4"
-  integrity sha512-wynEP02LmIbLpcYw8uBKpcfF6dmg2vcpKqxeH5UcoKEYdExslsdUA4ugFauuaeYdTB76ez6gJW8XAZ6CgkXYxA==
 
 nanoid@^3.3.4:
   version "3.3.4"
@@ -3217,11 +3197,6 @@ prop-types@^15.6.2, prop-types@^15.8.1:
     loose-envify "^1.4.0"
     object-assign "^4.1.1"
     react-is "^16.13.1"
-
-property-expr@^2.0.4:
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/property-expr/-/property-expr-2.0.5.tgz#278bdb15308ae16af3e3b9640024524f4dc02cb4"
-  integrity sha512-IJUkICM5dP5znhCckHSv30Q4b5/JA5enCtkRHYaOVOAocnH/1BQEYTC5NMfT3AVl/iXKdr3aqQbQn9DxyWknwA==
 
 punycode@^2.1.0:
   version "2.1.1"
@@ -3795,11 +3770,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-toposort@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/toposort/-/toposort-2.0.2.tgz#ae21768175d1559d48bef35420b2f4962f09c330"
-  integrity sha512-0a5EOkAUp8D4moMi2W8ZF8jcga7BgZd91O/yabJCFY8az+XSzeGyTKs0Aoo897iV1Nj6guFq8orWDS96z91oGg==
-
 tsconfig-paths@^3.14.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.14.1.tgz#ba0734599e8ea36c862798e920bcf163277b137a"
@@ -4020,18 +3990,10 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-yup@^0.32.11:
-  version "0.32.11"
-  resolved "https://registry.yarnpkg.com/yup/-/yup-0.32.11.tgz#d67fb83eefa4698607982e63f7ca4c5ed3cf18c5"
-  integrity sha512-Z2Fe1bn+eLstG8DRR6FTavGD+MeAwyfmouhHsIUgaADz8jvFKbO/fXc2trJKZg+5EBjh4gGm3iU/t3onKlXHIg==
-  dependencies:
-    "@babel/runtime" "^7.15.4"
-    "@types/lodash" "^4.14.175"
-    lodash "^4.17.21"
-    lodash-es "^4.17.21"
-    nanoclone "^0.2.1"
-    property-expr "^2.0.4"
-    toposort "^2.0.2"
+zod@^3.19.1:
+  version "3.19.1"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.19.1.tgz#112f074a97b50bfc4772d4ad1576814bd8ac4473"
+  integrity sha512-LYjZsEDhCdYET9ikFu6dVPGp2YH9DegXjdJToSzD9rO6fy4qiRYFoyEYwps88OseJlPyl2NOe2iJuhEhL7IpEA==
 
 zustand@4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## 概要

- Settingページからユーザー名、アバターを変更する機能を実装。
- YupをZodで置換
- JWTトークンの時間切れ設定を解除

## 動作確認

ログインして右上のメニューボタンからSettingの画面に行って、下記のアクションができるか確認

- ユーザー名の変更
- アバターのアップロード
- アバターの削除

## 関連イシュー

- resolve #96 
- resolve #114 
- resolve #135 