### PR TITLE
非公開のチャットルームにフレンドを入室できるようにした

### DIFF
--- a/backend/prisma/migrations/20221206064017_delete_surrogate_key/migration.sql
+++ b/backend/prisma/migrations/20221206064017_delete_surrogate_key/migration.sql
@@ -1,0 +1,26 @@
+/*
+  Warnings:
+
+  - The primary key for the `ChatroomAdmin` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `ChatroomAdmin` table. All the data in the column will be lost.
+  - The primary key for the `ChatroomMembers` table will be changed. If it partially fails, the table could be left without primary key constraint.
+  - You are about to drop the column `id` on the `ChatroomMembers` table. All the data in the column will be lost.
+  - A unique constraint covering the columns `[chatroomId,userId]` on the table `ChatroomAdmin` will be added. If there are existing duplicate values, this will fail.
+  - A unique constraint covering the columns `[chatroomId,userId]` on the table `ChatroomMembers` will be added. If there are existing duplicate values, this will fail.
+
+*/
+-- AlterTable
+ALTER TABLE "ChatroomAdmin" DROP CONSTRAINT "ChatroomAdmin_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "ChatroomAdmin_pkey" PRIMARY KEY ("chatroomId", "userId");
+
+-- AlterTable
+ALTER TABLE "ChatroomMembers" DROP CONSTRAINT "ChatroomMembers_pkey",
+DROP COLUMN "id",
+ADD CONSTRAINT "ChatroomMembers_pkey" PRIMARY KEY ("chatroomId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatroomAdmin_chatroomId_userId_key" ON "ChatroomAdmin"("chatroomId", "userId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ChatroomMembers_chatroomId_userId_key" ON "ChatroomMembers"("chatroomId", "userId");

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -62,13 +62,15 @@ enum ChatroomType {
 }
 
 model ChatroomMembers {
-  id         Int      @id @default(autoincrement())
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now()) @updatedAt
   chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   chatroomId Int
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId     Int
+
+  @@id([chatroomId, userId])
+  @@unique([chatroomId, userId])
 }
 
 model Message {
@@ -83,13 +85,15 @@ model Message {
 }
 
 model ChatroomAdmin {
-  id         Int      @id @default(autoincrement())
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now()) @updatedAt
   chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade) // Roomが消されたらメッセージも削除される
   chatroomId Int
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId     Int
+
+  @@id([chatroomId, userId])
+  @@unique([chatroomId, userId])
 }
 
 model GameRecord {

--- a/backend/src/friend/friends.controller.ts
+++ b/backend/src/friend/friends.controller.ts
@@ -55,9 +55,6 @@ export class FriendsController {
     @Query('userId', ParseIntPipe) userId: number,
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<Friend[]> {
-    console.log('joinable-friends userId:', userId);
-    console.log('joinable-friends roomId:', roomId);
-
     return await this.friendsService.findJoinableFriends(userId, roomId);
   }
 

--- a/backend/src/friend/friends.controller.ts
+++ b/backend/src/friend/friends.controller.ts
@@ -45,6 +45,23 @@ export class FriendsController {
   }
 
   /**
+   * @param userId
+   * @param roomId
+   * @return フォローしている かつ そのチャットルームに所属していないユーザーを返す
+   */
+  @Get('joinable')
+  async joinableFriends(
+    @Req() req: Request,
+    @Query('userId', ParseIntPipe) userId: number,
+    @Query('roomId', ParseIntPipe) roomId: number,
+  ): Promise<Friend[]> {
+    console.log('joinable-friends userId:', userId);
+    console.log('joinable-friends roomId:', roomId);
+
+    return await this.friendsService.findJoinableFriends(userId, roomId);
+  }
+
+  /**
    * @param CreateFriendDto
    * @return 実行結果をmessageで返す
    */

--- a/backend/src/friend/friends.service.ts
+++ b/backend/src/friend/friends.service.ts
@@ -101,6 +101,35 @@ export class FriendsService {
 
   /**
    * @param userId
+   * @param roomId
+   * @return フォローしている かつ チャットルームに入室していないユーザー一覧を返す
+   */
+  async findJoinableFriends(userId: number, roomId: number): Promise<Friend[]> {
+    const followingUsers = await this.findFollowingUsers(userId);
+
+    // chatroomに所属してるUserIdを取得する
+    const joinedUsers = await this.prisma.chatroomMembers.findMany({
+      where: {
+        chatroomId: roomId,
+      },
+      select: {
+        userId: true,
+      },
+    });
+
+    // idの配列に変更する
+    const joinedUserIds = joinedUsers.map((user) => user.userId);
+
+    // すでに入室しているユーザーを除去する
+    const joinableFriends = followingUsers.filter(
+      (user) => !joinedUserIds.includes(user.id),
+    );
+
+    return joinableFriends;
+  }
+
+  /**
+   * @param userId
    * @return boolean
    * Friendリレーションを作成することでUserのフォロー処理を行う
    */

--- a/frontend/api/friend/fetchJoinableFriends.ts
+++ b/frontend/api/friend/fetchJoinableFriends.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { Friend } from 'types/friend';
+
+type Props = {
+  userId: number;
+  roomId: number;
+};
+
+const endpoint = `${
+  process.env.NEXT_PUBLIC_API_URL as string
+}/friends/joinable`;
+
+export const fetchJoinableFriends = async ({ userId, roomId }: Props) => {
+  try {
+    const response = await axios.get<Friend[]>(endpoint, {
+      params: { userId: userId, roomId: roomId },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+
+    return [];
+  }
+};

--- a/frontend/components/chat/chatroom/ChatroomJoinDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomJoinDialog.tsx
@@ -18,7 +18,7 @@ import ChatIcon from '@mui/icons-material/Chat';
 import LockIcon from '@mui/icons-material/Lock';
 import { Chatroom } from '@prisma/client';
 import { Socket } from 'socket.io-client';
-import { CHATROOM_TYPE, ChatroomType } from 'types/chat';
+import { CHATROOM_TYPE, JoinChatroomInfo } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 
@@ -27,13 +27,6 @@ type Props = {
   rooms: Chatroom[];
   socket: Socket;
   onClose: () => void;
-};
-
-type JoinRoomInfo = {
-  userId: number;
-  roomId: number;
-  type: ChatroomType;
-  password?: string;
 };
 
 export const ChatroomJoinDialog = memo(function ChatroomJoinDialog({
@@ -106,7 +99,7 @@ export const ChatroomJoinDialog = memo(function ChatroomJoinDialog({
 
       return;
     }
-    const joinRoomInfo: JoinRoomInfo = {
+    const joinRoomInfo: JoinChatroomInfo = {
       userId: user.id,
       roomId: selectedRoom.id,
       type: selectedRoom.type,

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -7,15 +7,19 @@ import {
   Dialog,
   DialogActions,
   DialogContent,
-  DialogContentText,
+  InputLabel,
+  Select,
+  SelectChangeEvent,
+  MenuItem,
+  FormControl,
   DialogTitle,
   Alert,
   Box,
   Collapse,
 } from '@mui/material';
-import DeleteIcon from '@mui/icons-material/Delete';
+import SettingsIcon from '@mui/icons-material/Settings';
 import CloseIcon from '@mui/icons-material/Close';
-import { Chatroom } from 'types/chat';
+import { Chatroom, ChatroomSettings, CHATROOM_SETTINGS } from 'types/chat';
 import { Socket } from 'socket.io-client';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
@@ -29,6 +33,10 @@ type Props = {
 export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const [open, setOpen] = useState(false);
   const { data: user } = useQueryUser();
+  const [settingType, setSettingType] = useState<ChatroomSettings>(
+    CHATROOM_SETTINGS.SET_ADMIN,
+  );
+
   if (user === undefined) {
     return <Loading />;
   }
@@ -54,6 +62,10 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
 
   const handleClose = () => {
     setOpen(false);
+  };
+
+  const handleChangeSetting = (event: SelectChangeEvent) => {
+    setSettingType(event.target.value as ChatroomSettings);
   };
 
   const [warning, setWarning] = useState(false);
@@ -95,24 +107,49 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
       </Box>
       <ListItem
         secondaryAction={
-          <IconButton edge="end" aria-label="delete" onClick={handleClickOpen}>
-            <DeleteIcon />
+          <IconButton
+            edge="end"
+            aria-label="settings"
+            onClick={handleClickOpen}
+          >
+            <SettingsIcon />
           </IconButton>
         }
         divider
         button
       >
-        <Dialog
-          open={open}
-          onClose={handleClose}
-          aria-labelledby="alert-dialog-title"
-          aria-describedby="alert-dialog-description"
-        >
-          <DialogTitle id="alert-dialog-title">Delete Room?</DialogTitle>
+        <Dialog open={open} onClose={handleClose}>
+          <DialogTitle>Room Settings</DialogTitle>
           <DialogContent>
-            <DialogContentText id="alert-dialog-description">
-              {`Do you really want to delete the Room '${room.name}'?`}
-            </DialogContentText>
+            <FormControl sx={{ m: 1, minWidth: 120 }}>
+              <InputLabel id="room-setting-select-label">Setting</InputLabel>
+              <Select
+                labelId="room-setting-select-label"
+                id="room-setting"
+                value={settingType}
+                label="setting"
+                onChange={handleChangeSetting}
+              >
+                <MenuItem value={CHATROOM_SETTINGS.DELETE_ROOM}>
+                  {CHATROOM_SETTINGS.DELETE_ROOM}
+                </MenuItem>
+                <MenuItem value={CHATROOM_SETTINGS.SET_ADMIN}>
+                  {CHATROOM_SETTINGS.SET_ADMIN}
+                </MenuItem>
+                <MenuItem value={CHATROOM_SETTINGS.MUTE_USER}>
+                  {CHATROOM_SETTINGS.MUTE_USER}
+                </MenuItem>
+                <MenuItem value={CHATROOM_SETTINGS.BAN_USER}>
+                  {CHATROOM_SETTINGS.BAN_USER}
+                </MenuItem>
+                <MenuItem value={CHATROOM_SETTINGS.ADD_FRIEND}>
+                  {CHATROOM_SETTINGS.ADD_FRIEND}
+                </MenuItem>
+                <MenuItem value={CHATROOM_SETTINGS.CHANGE_PASSWORD}>
+                  {CHATROOM_SETTINGS.CHANGE_PASSWORD}
+                </MenuItem>
+              </Select>
+            </FormControl>
           </DialogContent>
           <DialogActions>
             <Button onClick={handleClose}>Disagree</Button>

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -33,9 +33,8 @@ type Props = {
 export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const [open, setOpen] = useState(false);
   const { data: user } = useQueryUser();
-  const [settingType, setSettingType] = useState<ChatroomSettings>(
-    CHATROOM_SETTINGS.SET_ADMIN,
-  );
+  const [selectedRoomSetting, setSelectedRoomSetting] =
+    useState<ChatroomSettings>(CHATROOM_SETTINGS.DELETE_ROOM);
 
   if (user === undefined) {
     return <Loading />;
@@ -47,38 +46,63 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     setCurrentRoomId(id);
   };
 
-  const deleteRoom = (id: number) => {
-    console.log('deleteRoom:', id);
-    const deleteRoomInfo = {
-      id: id,
-      userId: user.id,
-    };
-    socket.emit('chat:deleteRoom', deleteRoomInfo);
-  };
-
   const handleClickOpen = () => {
     setOpen(true);
   };
 
+  const initDialog = () => {
+    setSelectedRoomSetting(CHATROOM_SETTINGS.DELETE_ROOM);
+  };
+
   const handleClose = () => {
+    initDialog();
     setOpen(false);
   };
 
   const handleChangeSetting = (event: SelectChangeEvent) => {
-    setSettingType(event.target.value as ChatroomSettings);
+    setSelectedRoomSetting(event.target.value as ChatroomSettings);
   };
 
   const [warning, setWarning] = useState(false);
-  const handleDelete = () => {
-    handleClose();
+  const deleteRoom = () => {
+    console.log('deleteRoom:', room.id);
 
     // TODO: adminのハンドリングもチェックする
     // TODO: そもそも削除ボタンを表示しない
     if (user.id !== room.ownerId) {
       setWarning(true);
     } else {
-      deleteRoom(room.id);
+      const deleteRoomInfo = {
+        id: room.id,
+        userId: user.id,
+      };
+      socket.emit('chat:deleteRoom', deleteRoomInfo);
     }
+  };
+
+  const handleAction = () => {
+    switch (selectedRoomSetting) {
+      case CHATROOM_SETTINGS.DELETE_ROOM:
+        deleteRoom();
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.ADD_FRIEND:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.CHANGE_PASSWORD:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.SET_ADMIN:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.MUTE_USER:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.BAN_USER:
+        console.log(selectedRoomSetting);
+        break;
+    }
+    handleClose();
   };
 
   return (
@@ -126,7 +150,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
               <Select
                 labelId="room-setting-select-label"
                 id="room-setting"
-                value={settingType}
+                value={selectedRoomSetting}
                 label="setting"
                 onChange={handleChangeSetting}
               >
@@ -152,9 +176,9 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             </FormControl>
           </DialogContent>
           <DialogActions>
-            <Button onClick={handleClose}>Disagree</Button>
-            <Button onClick={handleDelete} autoFocus>
-              Agree
+            <Button onClick={handleClose}>Cancel</Button>
+            <Button onClick={handleAction} autoFocus>
+              OK
             </Button>
           </DialogActions>
         </Dialog>

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -70,6 +70,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     };
 
     // friendをチャットルームに追加する
+    // TODO:フレンドを入室させたあとのgatewayからのレスポンス対応は今後行う
     socket.emit('chat:joinRoom', joinRoomInfo);
   };
 

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -1,37 +1,19 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import {
   ListItem,
   IconButton,
   ListItemText,
-  Button,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  InputLabel,
-  Select,
-  SelectChangeEvent,
-  MenuItem,
-  FormControl,
-  DialogTitle,
   Alert,
   Box,
   Collapse,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import CloseIcon from '@mui/icons-material/Close';
-import {
-  Chatroom,
-  ChatroomSettings,
-  CHATROOM_SETTINGS,
-  CHATROOM_TYPE,
-  ChatroomType,
-  JoinChatroomInfo,
-} from 'types/chat';
 import { Socket } from 'socket.io-client';
+import { Chatroom, ChatroomType, JoinChatroomInfo } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
-import { Friend } from 'types/friend';
-import { fetchJoinableFriends } from 'api/friend/fetchJoinableFriends';
+import { ChatroomSettingDialog } from 'components/chat/chatroom/ChatroomSettingDialog';
 
 type Props = {
   room: Chatroom;
@@ -42,36 +24,6 @@ type Props = {
 export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const [open, setOpen] = useState(false);
   const { data: user } = useQueryUser();
-  const [selectedRoomSetting, setSelectedRoomSetting] =
-    useState<ChatroomSettings>(CHATROOM_SETTINGS.DELETE_ROOM);
-  const [selectedFriendId, setSelectedFriendId] = useState('');
-  const [friends, setFriends] = useState<Friend[]>([]);
-
-  useEffect(() => {
-    if (user === undefined) return;
-    // フレンドを追加する項目を選択時に取得する
-    if (selectedRoomSetting === CHATROOM_SETTINGS.ADD_FRIEND) return;
-
-    const fetchFriends = async () => {
-      // フォローしている かつ そのチャットルームに所属していないユーザーを取得する
-      //      const res = await fetchFollowingUsers({ userId: user.id });
-      const res = await fetchJoinableFriends({
-        userId: user.id,
-        roomId: room.id,
-      });
-      console.log('joinable:', res);
-
-      setFriends(res);
-    };
-
-    fetchFriends()
-      .then((res) => {
-        console.log(res);
-      })
-      .catch((err) => {
-        console.log(err);
-      });
-  }, [selectedRoomSetting]);
 
   if (user === undefined) {
     return <Loading />;
@@ -87,23 +39,8 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     setOpen(true);
   };
 
-  const initDialog = () => {
-    setSelectedRoomSetting(CHATROOM_SETTINGS.DELETE_ROOM);
-    setSelectedFriendId('');
-  };
-
   const handleClose = () => {
-    initDialog();
     setOpen(false);
-  };
-
-  /// ダイアログで項目を変更したときの処理
-  const handleChangeSetting = (event: SelectChangeEvent) => {
-    setSelectedRoomSetting(event.target.value as ChatroomSettings);
-  };
-
-  const handleChangeFriend = (event: SelectChangeEvent) => {
-    setSelectedFriendId(event.target.value);
   };
 
   const [warning, setWarning] = useState(false);
@@ -123,44 +60,17 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     }
   };
 
-  const addFriend = () => {
+  const addFriend = (friendId: number) => {
     console.log();
     // フレンドを選択する
     const joinRoomInfo: JoinChatroomInfo = {
-      userId: Number(selectedFriendId),
+      userId: friendId,
       roomId: room.id,
       type: room.type as ChatroomType,
     };
 
-    socket.emit('chat:joinRoom', joinRoomInfo, (response: any) => {
-      console.log(response);
-    });
-  };
-
-  const handleAction = () => {
-    switch (selectedRoomSetting) {
-      case CHATROOM_SETTINGS.DELETE_ROOM:
-        deleteRoom();
-        console.log(selectedRoomSetting);
-        break;
-      case CHATROOM_SETTINGS.ADD_FRIEND:
-        addFriend();
-        console.log(selectedRoomSetting);
-        break;
-      case CHATROOM_SETTINGS.CHANGE_PASSWORD:
-        console.log(selectedRoomSetting);
-        break;
-      case CHATROOM_SETTINGS.SET_ADMIN:
-        console.log(selectedRoomSetting);
-        break;
-      case CHATROOM_SETTINGS.MUTE_USER:
-        console.log(selectedRoomSetting);
-        break;
-      case CHATROOM_SETTINGS.BAN_USER:
-        console.log(selectedRoomSetting);
-        break;
-    }
-    handleClose();
+    // friendをチャットルームに追加する
+    socket.emit('chat:joinRoom', joinRoomInfo);
   };
 
   return (
@@ -187,90 +97,51 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
           </Alert>
         </Collapse>
       </Box>
-      <ListItem
-        secondaryAction={
-          <IconButton
-            edge="end"
-            aria-label="settings"
-            onClick={handleClickOpen}
-          >
-            <SettingsIcon />
-          </IconButton>
-        }
-        divider
-        button
-      >
-        <Dialog open={open} onClose={handleClose}>
-          <DialogTitle>Room Settings</DialogTitle>
-          <DialogContent>
-            <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
-              <InputLabel id="room-setting-select-label">Setting</InputLabel>
-              <Select
-                labelId="room-setting-select-label"
-                id="room-setting"
-                value={selectedRoomSetting}
-                label="setting"
-                onChange={handleChangeSetting}
-              >
-                <MenuItem value={CHATROOM_SETTINGS.DELETE_ROOM}>
-                  {CHATROOM_SETTINGS.DELETE_ROOM}
-                </MenuItem>
-                <MenuItem value={CHATROOM_SETTINGS.SET_ADMIN}>
-                  {CHATROOM_SETTINGS.SET_ADMIN}
-                </MenuItem>
-                <MenuItem value={CHATROOM_SETTINGS.MUTE_USER}>
-                  {CHATROOM_SETTINGS.MUTE_USER}
-                </MenuItem>
-                <MenuItem value={CHATROOM_SETTINGS.BAN_USER}>
-                  {CHATROOM_SETTINGS.BAN_USER}
-                </MenuItem>
-                <MenuItem value={CHATROOM_SETTINGS.ADD_FRIEND}>
-                  {CHATROOM_SETTINGS.ADD_FRIEND}
-                </MenuItem>
-                <MenuItem value={CHATROOM_SETTINGS.CHANGE_PASSWORD}>
-                  {CHATROOM_SETTINGS.CHANGE_PASSWORD}
-                </MenuItem>
-              </Select>
-            </FormControl>
-          </DialogContent>
-          {selectedRoomSetting === CHATROOM_SETTINGS.ADD_FRIEND && (
-            <DialogContent>
-              <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
-                <InputLabel id="room-setting-select-label">Friend</InputLabel>
-                <Select
-                  labelId="room-setting-select-label"
-                  id="room-setting"
-                  value={selectedFriendId}
-                  label="setting"
-                  onChange={handleChangeFriend}
-                >
-                  {/* menuItemをmapで出力する */}
-                  {friends.map((friend) => (
-                    <MenuItem value={String(friend.id)} key={friend.id}>
-                      {friend.name}
-                    </MenuItem>
-                  ))}
-                </Select>
-              </FormControl>
-            </DialogContent>
-          )}
-          <DialogActions>
-            <Button onClick={handleClose}>Cancel</Button>
-            <Button onClick={handleAction} autoFocus>
-              OK
-            </Button>
-          </DialogActions>
-        </Dialog>
-        <ListItemText
-          primary={room.name}
-          onClick={() => {
-            getMessage(room.id);
-          }}
-          style={{
-            overflow: 'hidden',
-          }}
-        />
-      </ListItem>
+      {/* TODO: 一旦ルーム作成者のみに設定ボタンが表示されるようにしている */}
+      {user.id === room.ownerId ? (
+        <ListItem
+          secondaryAction={
+            <IconButton
+              edge="end"
+              aria-label="settings"
+              onClick={handleClickOpen}
+            >
+              <SettingsIcon />
+            </IconButton>
+          }
+          divider
+          button
+        >
+          <ChatroomSettingDialog
+            room={room}
+            open={open}
+            onClose={handleClose}
+            deleteRoom={deleteRoom}
+            addFriend={addFriend}
+          />
+          <ListItemText
+            primary={room.name}
+            onClick={() => {
+              getMessage(room.id);
+            }}
+            style={{
+              overflow: 'hidden',
+            }}
+          />
+        </ListItem>
+      ) : (
+        <ListItem divider button>
+          <ListItemText
+            primary={room.name}
+            onClick={() => {
+              getMessage(room.id);
+            }}
+            style={{
+              overflow: 'hidden',
+            }}
+          />
+        </ListItem>
+      )}
     </>
   );
 };

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -1,0 +1,197 @@
+import { useState, useEffect, memo } from 'react';
+import {
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  InputLabel,
+  Select,
+  SelectChangeEvent,
+  MenuItem,
+  FormControl,
+  DialogTitle,
+} from '@mui/material';
+import {
+  Chatroom,
+  ChatroomSettings,
+  CHATROOM_SETTINGS,
+  CHATROOM_TYPE,
+} from 'types/chat';
+import { Friend } from 'types/friend';
+import { fetchJoinableFriends } from 'api/friend/fetchJoinableFriends';
+import { useQueryUser } from 'hooks/useQueryUser';
+import { Loading } from 'components/common/Loading';
+
+type Props = {
+  room: Chatroom;
+  open: boolean;
+  onClose: () => void;
+  deleteRoom: () => void;
+  addFriend: (friendId: number) => void;
+};
+
+export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
+  room,
+  open,
+  onClose,
+  deleteRoom,
+  addFriend,
+}: Props) {
+  const { data: user } = useQueryUser();
+  const [selectedRoomSetting, setSelectedRoomSetting] =
+    useState<ChatroomSettings>(CHATROOM_SETTINGS.DELETE_ROOM);
+  const [selectedFriendId, setSelectedFriendId] = useState('');
+  const [friends, setFriends] = useState<Friend[]>([]);
+
+  useEffect(() => {
+    if (user === undefined) return;
+    // フレンドを追加する項目を選択時に取得する
+    if (selectedRoomSetting === CHATROOM_SETTINGS.ADD_FRIEND) return;
+
+    const fetchFriends = async () => {
+      // フォローしている かつ そのチャットルームに所属していないユーザーを取得する
+      const res = await fetchJoinableFriends({
+        userId: user.id,
+        roomId: room.id,
+      });
+
+      setFriends(res);
+    };
+
+    fetchFriends()
+      .then((res) => {
+        console.log(res);
+      })
+      .catch((err) => {
+        console.log(err);
+      });
+  }, [selectedRoomSetting]);
+
+  if (user === undefined) {
+    return <Loading />;
+  }
+
+  const initDialog = () => {
+    setSelectedRoomSetting(CHATROOM_SETTINGS.DELETE_ROOM);
+    setSelectedFriendId('');
+  };
+
+  const handleClose = () => {
+    initDialog();
+    onClose();
+  };
+
+  /// ダイアログで項目を変更したときの処理
+  const handleChangeSetting = (event: SelectChangeEvent) => {
+    setSelectedRoomSetting(event.target.value as ChatroomSettings);
+  };
+
+  const handleChangeFriend = (event: SelectChangeEvent) => {
+    setSelectedFriendId(event.target.value);
+  };
+
+  const handleAction = () => {
+    switch (selectedRoomSetting) {
+      case CHATROOM_SETTINGS.DELETE_ROOM:
+        deleteRoom();
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.ADD_FRIEND:
+        addFriend(Number(selectedFriendId));
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.CHANGE_PASSWORD:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.SET_ADMIN:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.MUTE_USER:
+        console.log(selectedRoomSetting);
+        break;
+      case CHATROOM_SETTINGS.BAN_USER:
+        console.log(selectedRoomSetting);
+        break;
+    }
+    handleClose();
+  };
+
+  return (
+    <>
+      <Dialog open={open} onClose={handleClose}>
+        <DialogTitle>Room Settings</DialogTitle>
+        <DialogContent>
+          <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
+            <InputLabel id="room-setting-select-label">Setting</InputLabel>
+            <Select
+              labelId="room-setting-select-label"
+              id="room-setting"
+              value={selectedRoomSetting}
+              label="setting"
+              onChange={handleChangeSetting}
+            >
+              <MenuItem value={CHATROOM_SETTINGS.DELETE_ROOM}>
+                {CHATROOM_SETTINGS.DELETE_ROOM}
+              </MenuItem>
+              <MenuItem value={CHATROOM_SETTINGS.SET_ADMIN}>
+                {CHATROOM_SETTINGS.SET_ADMIN}
+              </MenuItem>
+              <MenuItem value={CHATROOM_SETTINGS.MUTE_USER}>
+                {CHATROOM_SETTINGS.MUTE_USER}
+              </MenuItem>
+              <MenuItem value={CHATROOM_SETTINGS.BAN_USER}>
+                {CHATROOM_SETTINGS.BAN_USER}
+              </MenuItem>
+              {/* 非公開のルームのみフレンドを追加ボタンが選択可能 */}
+              {room.type === CHATROOM_TYPE.PRIVATE && (
+                <MenuItem value={CHATROOM_SETTINGS.ADD_FRIEND}>
+                  {CHATROOM_SETTINGS.ADD_FRIEND}
+                </MenuItem>
+              )}
+              <MenuItem value={CHATROOM_SETTINGS.CHANGE_PASSWORD}>
+                {CHATROOM_SETTINGS.CHANGE_PASSWORD}
+              </MenuItem>
+            </Select>
+          </FormControl>
+        </DialogContent>
+        {selectedRoomSetting === CHATROOM_SETTINGS.ADD_FRIEND && (
+          <>
+            {friends.length === 0 ? (
+              <div
+                className="mb-4 flex justify-center rounded-lg bg-red-100 p-4 text-sm text-red-700 dark:bg-red-200 dark:text-red-800"
+                role="alert"
+              >
+                <span className="font-medium">No users are available.</span>
+              </div>
+            ) : (
+              <DialogContent>
+                <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
+                  <InputLabel id="room-setting-select-label">Friend</InputLabel>
+                  <Select
+                    labelId="room-setting-select-label"
+                    id="room-setting"
+                    value={selectedFriendId}
+                    label="setting"
+                    onChange={handleChangeFriend}
+                  >
+                    {friends.map((friend) => (
+                      <MenuItem value={String(friend.id)} key={friend.id}>
+                        {friend.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </DialogContent>
+            )}
+          </>
+        )}
+        <DialogActions>
+          <Button onClick={handleClose}>Cancel</Button>
+          <Button onClick={handleAction} autoFocus>
+            OK
+          </Button>
+        </DialogActions>
+      </Dialog>
+    </>
+  );
+});

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -22,23 +22,27 @@ model Chatroom {
 }
 
 model ChatroomAdmin {
-  id         Int      @id @default(autoincrement())
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now())
   chatroomId Int
   userId     Int
   Chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   User       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([chatroomId, userId])
+  @@unique([chatroomId, userId])
 }
 
 model ChatroomMembers {
-  id         Int      @id @default(autoincrement())
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now())
   chatroomId Int
   userId     Int
   Chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   User       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@id([chatroomId, userId])
+  @@unique([chatroomId, userId])
 }
 
 model FriendRelation {

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -28,12 +28,12 @@ export const CHATROOM_TYPE = {
 export type ChatroomType = typeof CHATROOM_TYPE[keyof typeof CHATROOM_TYPE];
 
 export const CHATROOM_SETTINGS = {
-  DELETE_ROOM: 'Delete room',
-  ADD_FRIEND: 'Add friend', // private room
-  CHANGE_PASSWORD: 'Change password', // protected room
-  SET_ADMIN: 'Set admin',
-  MUTE_USER: 'Mute user',
-  BAN_USER: 'Ban user',
+  DELETE_ROOM: 'Delete Room',
+  ADD_FRIEND: 'Add Friend', // private room
+  CHANGE_PASSWORD: 'Change Password', // protected room
+  SET_ADMIN: 'Set Admin',
+  MUTE_USER: 'Mute User',
+  BAN_USER: 'Ban User',
 } as const;
 
 export type ChatroomSettings =

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -26,3 +26,15 @@ export const CHATROOM_TYPE = {
 } as const;
 
 export type ChatroomType = typeof CHATROOM_TYPE[keyof typeof CHATROOM_TYPE];
+
+export const CHATROOM_SETTINGS = {
+  DELETE_ROOM: 'Delete room',
+  ADD_FRIEND: 'Add friend', // private room
+  CHANGE_PASSWORD: 'Change password', // protected room
+  SET_ADMIN: 'Set admin',
+  MUTE_USER: 'Mute user',
+  BAN_USER: 'Ban user',
+} as const;
+
+export type ChatroomSettings =
+  typeof CHATROOM_SETTINGS[keyof typeof CHATROOM_SETTINGS];

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -13,6 +13,13 @@ export type CreateChatroomInfo = {
   password?: string;
 };
 
+export type JoinChatroomInfo = {
+  userId: number;
+  roomId: number;
+  type: ChatroomType;
+  password?: string;
+};
+
 export type Message = {
   ChatroomId: number;
   userId: number;


### PR DESCRIPTION
## 実装経緯

- これまで非公開のルームに入る方法がなかった
- そのため非公開のルームの作成者が、フレンドをルームに入室できるようにした
- それに伴いこれまで右側に表示されていた削除ボタンを設定ボタンに変更している

## 動作確認事項
- ルームの作成者のみに設定ボタンが表示されること
- 設定ボタンからルームの削除が行えること
- 非公開のルームの設定ボタンのみに、フレンドを追加する項目が表示されること
- 非公開のルームにフレンドを追加できること

## 次回以降やること
- 今回対応したもの以外の設定項目に対応する

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/122