### PR TITLE
Setting画面でのエラーをフロントエンドで表示

### DIFF
--- a/frontend/components/game/battle/Play.tsx
+++ b/frontend/components/game/battle/Play.tsx
@@ -273,7 +273,14 @@ export const Play = ({ updateFinishedGameInfo }: Props) => {
       'finishGame',
       (updatedPoint: number | null, finishedGameInfo: FinishedGameInfo) => {
         if (user !== undefined && updatedPoint !== null)
-          updatePointMutation.mutate({ userId: user.id, updatedPoint });
+          updatePointMutation.mutate(
+            { userId: user.id, updatedPoint },
+            {
+              onError: () => {
+                updatePlayState(PlayState.stateNothing);
+              },
+            },
+          );
         updateFinishedGameInfo(finishedGameInfo);
         updatePlayState(PlayState.stateFinished);
       },

--- a/frontend/components/game/battle/Play.tsx
+++ b/frontend/components/game/battle/Play.tsx
@@ -5,7 +5,7 @@ import { usePlayerNamesStore } from 'store/game/PlayerNames';
 import { usePlayStateStore, PlayState } from 'store/game/PlayState';
 import { GameHeader } from 'components/game/battle/GameHeader';
 import { FinishedGameInfo } from 'types/game';
-import { useMutatePoint } from 'hooks/useMutatePoint';
+import { useMutationPoint } from 'hooks/useMutationPoint';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 import { useGameSettingStore } from 'store/game/GameSetting';
@@ -116,7 +116,7 @@ export const Play = ({ updateFinishedGameInfo }: Props) => {
   const [changeCount, updateChangeCount] = useState(true);
   const [isArrowDownPressed, updateIsArrowDownPressed] = useState(false);
   const [isArrowUpPressed, updateIsArrowUpPressed] = useState(false);
-  const { updatePointMutation } = useMutatePoint();
+  const { updatePointMutation } = useMutationPoint();
   const { data: user } = useQueryUser();
   const FPS = 60;
   const waitMillSec = 1000 / FPS;

--- a/frontend/components/game/home/Profile.tsx
+++ b/frontend/components/game/home/Profile.tsx
@@ -21,6 +21,7 @@ export const Profile = () => {
       <Grid container spacing={2}>
         <Grid
           container
+          item
           direction="column"
           xs={6}
           justifyContent="center"

--- a/frontend/hooks/useMutationAvatar.tsx
+++ b/frontend/hooks/useMutationAvatar.tsx
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
-export const useMutateAvatar = () => {
+export const useMutationAvatar = () => {
   const queryClient = useQueryClient();
 
   const updateAvatarMutation = useMutation<
@@ -60,7 +60,6 @@ export const useMutateAvatar = () => {
       },
       onError: (err: AxiosError) => {
         console.log(err);
-        throw err;
       },
     },
   );

--- a/frontend/hooks/useMutationAvatar.tsx
+++ b/frontend/hooks/useMutationAvatar.tsx
@@ -59,7 +59,6 @@ export const useMutateAvatar = () => {
         }
       },
       onError: (err: AxiosError) => {
-        // [TODO] エラーがあった場合に、UI上もなにかアラートを出す
         console.log(err);
         throw err;
       },

--- a/frontend/hooks/useMutationName.tsx
+++ b/frontend/hooks/useMutationName.tsx
@@ -28,7 +28,6 @@ export const useMutateName = () => {
         }
       },
       onError: (err: AxiosError) => {
-        // [TODO] エラーがあった場合に、UI上もなにかアラートを出す
         console.log(err);
         throw err;
       },

--- a/frontend/hooks/useMutationName.tsx
+++ b/frontend/hooks/useMutationName.tsx
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
-export const useMutateName = () => {
+export const useMutationName = () => {
   const queryClient = useQueryClient();
 
   const updateNameMutation = useMutation<
@@ -29,7 +29,6 @@ export const useMutateName = () => {
       },
       onError: (err: AxiosError) => {
         console.log(err);
-        throw err;
       },
     },
   );

--- a/frontend/hooks/useMutationPoint.tsx
+++ b/frontend/hooks/useMutationPoint.tsx
@@ -2,7 +2,7 @@ import axios, { AxiosError } from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
-export const useMutatePoint = () => {
+export const useMutationPoint = () => {
   const queryClient = useQueryClient();
 
   const updatePointMutation = useMutation<
@@ -29,7 +29,6 @@ export const useMutatePoint = () => {
       },
       onError: (err: AxiosError) => {
         console.log(err);
-        throw err;
       },
     },
   );

--- a/frontend/hooks/useMutationPoint.tsx
+++ b/frontend/hooks/useMutationPoint.tsx
@@ -1,4 +1,4 @@
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { useQueryClient, useMutation } from '@tanstack/react-query';
 import { User } from '@prisma/client';
 
@@ -7,14 +7,18 @@ export const useMutationPoint = () => {
 
   const updatePointMutation = useMutation<
     Omit<User, 'hashedPassword'>,
-    AxiosError,
+    Error,
     { userId: number; updatedPoint: number }
   >(
     async ({ userId, updatedPoint }) => {
+      if (Number.isNaN(userId) || Number.isNaN(updatedPoint)) throw new Error();
+
       const { data } = await axios.patch<Omit<User, 'hashedPassword'>>(
         `${process.env.NEXT_PUBLIC_API_URL as string}/user/point/${userId}`,
         { point: updatedPoint },
       );
+
+      if (Object.keys(data).length === 0) throw new Error();
 
       return data;
     },
@@ -27,7 +31,7 @@ export const useMutationPoint = () => {
           queryClient.setQueryData(['user'], res);
         }
       },
-      onError: (err: AxiosError) => {
+      onError: (err: Error) => {
         console.log(err);
       },
     },

--- a/frontend/hooks/useQueryGameRecords.tsx
+++ b/frontend/hooks/useQueryGameRecords.tsx
@@ -1,11 +1,8 @@
-import { useRouter } from 'next/router';
 import axios, { AxiosError } from 'axios';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQuery } from '@tanstack/react-query';
 import { GameRecordWithUserName } from 'types/game';
 
 export const useQueryGameRecords = (userId: number | undefined) => {
-  const queryClient = useQueryClient();
-  const router = useRouter();
   const getGameRecords = async () => {
     if (userId === undefined) return undefined;
     const { data } = await axios.get<GameRecordWithUserName[]>(
@@ -19,16 +16,8 @@ export const useQueryGameRecords = (userId: number | undefined) => {
     queryKey: ['game', userId],
     queryFn: getGameRecords,
     onError: (err: AxiosError) => {
-      if (
-        err.response &&
-        (err.response.status === 401 || err.response.status === 403)
-      ) {
-        queryClient.removeQueries(['user']);
-        void axios.post(
-          `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-        );
-        void router.push('/');
-      }
+      console.log(err);
+      throw err;
     },
   });
 };

--- a/frontend/hooks/useQueryGameRecords.tsx
+++ b/frontend/hooks/useQueryGameRecords.tsx
@@ -10,11 +10,6 @@ export const useQueryGameRecords = (userId: number | undefined) => {
       `${process.env.NEXT_PUBLIC_API_URL as string}/records/${userId}`,
     );
 
-    // findUniqueの戻り値がnullの場合、dataはnullではなく''になるため
-    // data === nullだとエラー判定ができないことからこのようなif文にしている
-    if (Object.keys(data).length === 0)
-      throw new Error('User records not found');
-
     return data;
   };
 

--- a/frontend/pages/game/battle/index.tsx
+++ b/frontend/pages/game/battle/index.tsx
@@ -19,7 +19,6 @@ const Battle: NextPage = () => {
   const [finishedGameInfo, setFinishedGameInfo] = useState(
     defaultFinishedGameInfo,
   );
-  console.log(playState);
 
   return (
     <Layout title="Play">

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -10,7 +10,7 @@ import {
 } from '@mui/material';
 import { Header } from 'components/common/Header';
 import { Layout } from 'components/common/Layout';
-import { useMutateName } from 'hooks/useMutationName';
+import { useMutationName } from 'hooks/useMutationName';
 import { useQueryUser } from 'hooks/useQueryUser';
 import type { NextPage } from 'next';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
@@ -18,7 +18,7 @@ import { SettingForm } from 'types/setting';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import { ChangeEventHandler, useState } from 'react';
-import { useMutateAvatar } from 'hooks/useMutationAvatar';
+import { useMutationAvatar } from 'hooks/useMutationAvatar';
 import { Loading } from 'components/common/Loading';
 import { AxiosError } from 'axios';
 import { AxiosErrorResponse } from 'types';
@@ -41,8 +41,8 @@ const Setting: NextPage = () => {
     mode: 'onSubmit',
     resolver: zodResolver(schema),
   });
-  const { updateNameMutation } = useMutateName();
-  const { updateAvatarMutation, deleteAvatarMutation } = useMutateAvatar();
+  const { updateNameMutation } = useMutationName();
+  const { updateAvatarMutation, deleteAvatarMutation } = useMutationAvatar();
 
   if (user === undefined) return <Loading fullHeight />;
 
@@ -199,10 +199,6 @@ const Setting: NextPage = () => {
                   error={errors.username ? true : false}
                   helperText={errors.username?.message}
                   sx={{ my: 2 }}
-                  onClick={() => {
-                    clearErrors();
-                    setError([]);
-                  }}
                 />
               )}
             />
@@ -216,7 +212,14 @@ const Setting: NextPage = () => {
           sx={{ p: 2 }}
         >
           <Grid item>
-            <Button variant="contained" type="submit">
+            <Button
+              variant="contained"
+              type="submit"
+              onClick={() => {
+                clearErrors();
+                setError([]);
+              }}
+            >
               Update username
             </Button>
           </Grid>

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -45,7 +45,6 @@ const Setting: NextPage = () => {
   const { updateAvatarMutation, deleteAvatarMutation } = useMutateAvatar();
 
   if (user === undefined) return <Loading fullHeight />;
-  const registeredUsername = register('username');
 
   const avatarImageUrl =
     user.avatarPath !== null
@@ -119,10 +118,7 @@ const Setting: NextPage = () => {
   return (
     <Layout title="Setting">
       <Header title="Setting" />
-      <form
-        // [TODO] type coercionをできればなくしたい
-        onSubmit={handleSubmit(onSubmit) as VoidFunction}
-      >
+      <form onSubmit={handleSubmit(onSubmit) as VoidFunction}>
         <Grid
           container
           alignItems="center"
@@ -193,15 +189,8 @@ const Setting: NextPage = () => {
               control={control}
               render={() => (
                 <TextField
-                  // Props spreadingがeslintで禁止されているために全部書き下している
-                  // Props spreadingができれば{...register('username')}でいける
-                  // [TODO] type coercionをできればなくしたい
-                  onChange={
-                    registeredUsername.onChange as unknown as VoidFunction
-                  }
-                  onBlur={registeredUsername.onBlur as unknown as VoidFunction}
-                  name={registeredUsername.name}
-                  ref={registeredUsername.ref}
+                  // eslint-disable-next-line react/jsx-props-no-spreading
+                  {...register('username')}
                   fullWidth
                   required
                   id="user-name"

--- a/frontend/store/game/PlayState.tsx
+++ b/frontend/store/game/PlayState.tsx
@@ -1,13 +1,15 @@
 import create from 'zustand';
 
-enum PlayState {
-  stateNothing,
-  stateWaiting,
-  stateSelecting,
-  stateStandingBy,
-  statePlaying,
-  stateFinished,
-}
+export const PlayState = {
+  stateNothing: 0,
+  stateWaiting: 1,
+  stateSelecting: 2,
+  stateStandingBy: 3,
+  statePlaying: 4,
+  stateFinished: 5,
+} as const;
+
+export type PlayState = typeof PlayState[keyof typeof PlayState];
 
 type State = {
   playState: PlayState;
@@ -21,5 +23,3 @@ export const usePlayStateStore = create<State>((set) => ({
       playState: payload,
     }),
 }));
-
-export { PlayState };


### PR DESCRIPTION
## 概要

Setting画面で重複するユーザーネームを設定しようとしたり、Read権限のないファイルをアバターに設定したりしようとするとUI上にエラーを表示するようにした。
その他諸々、コメントを消したり、フロントエンドでエラー出てたところを修正したり。

12/7 追記
以前指摘のあった、enumを使っている部分も修正しました。

## 関連イシュー

- resolve #137 
- resolve #142 