### PR TITLE
ユーザーステータスの追加など諸々

### DIFF
--- a/backend/prisma/migrations/20221208084418_user_status/migration.sql
+++ b/backend/prisma/migrations/20221208084418_user_status/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "UserStatus" AS ENUM ('ONLINE', 'PLAYING', 'OFFLINE');
+
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "status" "UserStatus" NOT NULL DEFAULT 'OFFLINE';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -15,6 +15,7 @@ model User {
   hashedPassword  String?
   point           Int               @default(1000)
   avatarPath      String?
+  status          UserStatus        @default(OFFLINE)
   chatroomOwners  Chatroom[]
   chatroomAdmins  ChatroomAdmin[]
   chatroomMembers ChatroomMembers[]
@@ -23,6 +24,12 @@ model User {
   messages        Message[]
   followers       FriendRelation[]  @relation("follower")
   followings      FriendRelation[]  @relation("following")
+}
+
+enum UserStatus {
+  ONLINE
+  PLAYING
+  OFFLINE
 }
 
 model FriendRelation {

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -11,6 +11,7 @@ import {
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
 import { AuthDto } from './dto/auth.dto';
+import { LogoutDto } from './dto/logout.dto';
 import { Csrf, Msg } from './interfaces/auth.interface';
 
 @Controller('auth')
@@ -48,7 +49,13 @@ export class AuthController {
 
   @HttpCode(HttpStatus.OK)
   @Post('logout')
-  logout(@Req() req: Request, @Res({ passthrough: true }) res: Response): Msg {
+  async logout(
+    @Req() req: Request,
+    @Res({ passthrough: true }) res: Response,
+    @Body() dto: LogoutDto,
+  ): Promise<Msg> {
+    await this.authService.logout(dto);
+
     res.cookie('access_token', '', {
       httpOnly: true,
       secure: true, //Postmanからアクセスするときはfalse

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -6,6 +6,7 @@ import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma/prisma.service';
 import { AuthDto } from './dto/auth.dto';
 import { Msg, Jwt } from './interfaces/auth.interface';
+import { LogoutDto } from './dto/logout.dto';
 
 @Injectable()
 export class AuthService {
@@ -52,7 +53,27 @@ export class AuthService {
     if (!isValid)
       throw new ForbiddenException('username or password incorrect');
 
+    await this.prisma.user.update({
+      where: {
+        id: user.id,
+      },
+      data: {
+        status: 'ONLINE',
+      },
+    });
+
     return this.generateJwt(user.id, user.name);
+  }
+
+  async logout(dto: LogoutDto) {
+    await this.prisma.user.update({
+      where: {
+        id: dto.id,
+      },
+      data: {
+        status: 'OFFLINE',
+      },
+    });
   }
 
   async generateJwt(userId: number, username: string): Promise<Jwt> {

--- a/backend/src/auth/dto/logout.dto.ts
+++ b/backend/src/auth/dto/logout.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class LogoutDto {
+  @IsNumber()
+  @IsNotEmpty()
+  id: number;
+}

--- a/backend/src/user/user.controller.ts
+++ b/backend/src/user/user.controller.ts
@@ -11,12 +11,13 @@ import {
   UploadedFile,
   UseGuards,
   UseInterceptors,
+  Query,
 } from '@nestjs/common';
 import { AuthGuard } from '@nestjs/passport';
 import { Request } from 'express';
 import { UserService } from './user.service';
 import { UpdateNameDto } from './dto/update-name.dto';
-import { User } from '@prisma/client';
+import { User, UserStatus } from '@prisma/client';
 import { UpdatePointDto } from './dto/update-point.dto';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { diskStorage } from 'multer';
@@ -51,6 +52,14 @@ export class UserController {
   getLoginUser(@Req() req: Request): Omit<User, 'hashedPassword'> {
     // custom.d.ts で型変換してる
     return req.user;
+  }
+
+  @Get('status')
+  async getStatus(
+    @Req() req: Request,
+    @Query('id', ParseIntPipe) id: number,
+  ): Promise<UserStatus | undefined> {
+    return await this.userService.getStatus(id);
   }
 
   @Get(':id')

--- a/backend/src/user/user.service.ts
+++ b/backend/src/user/user.service.ts
@@ -6,7 +6,7 @@ import {
 } from '@nestjs/common';
 import { PrismaService } from '../prisma/prisma.service';
 import { UpdateNameDto } from './dto/update-name.dto';
-import { Prisma, User } from '@prisma/client';
+import { Prisma, User, UserStatus } from '@prisma/client';
 import { UpdatePointDto } from './dto/update-point.dto';
 import { UpdateAvatarDto } from './dto/update-avatar.dto';
 import { createReadStream, unlink } from 'node:fs';
@@ -152,5 +152,12 @@ export class UserService {
       console.log(error);
       throw error;
     }
+  }
+
+  async getStatus(id: number): Promise<UserStatus | undefined> {
+    const user = await this.findOne(id);
+    if (user === null) return undefined;
+
+    return user.status;
   }
 }

--- a/frontend/api/user/getUserStatusById.ts
+++ b/frontend/api/user/getUserStatusById.ts
@@ -1,0 +1,25 @@
+import axios from 'axios';
+import { UserStatus } from '@prisma/client';
+
+type Props = {
+  userId: number;
+};
+
+const endpoint = `${process.env.NEXT_PUBLIC_API_URL as string}/user/status`;
+
+export const getUserStatusById = async ({ userId }: Props) => {
+  try {
+    if (Number.isNaN(userId)) throw new Error('UserId is invalid');
+    const { data } = await axios.get<UserStatus>(endpoint, {
+      params: { id: userId },
+    });
+
+    if (Object.keys(data).length === 0) throw new Error('User not found');
+
+    return data;
+  } catch (error) {
+    console.error(error);
+
+    return 'OFFLINE';
+  }
+};

--- a/frontend/components/chat/friend/FriendAddDialog.tsx
+++ b/frontend/components/chat/friend/FriendAddDialog.tsx
@@ -18,6 +18,7 @@ import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 import { followUser } from 'api/friend/followUser';
 import type { Friend } from 'types/friend';
+import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
 
 type Props = {
   open: boolean;
@@ -102,7 +103,7 @@ export const FriendAddDialog = memo(function FriendAddDialog({
                   button
                 >
                   <ListItemAvatar>
-                    <Avatar sx={{ bgcolor: blue[100], color: blue[600] }} />
+                    <Avatar src={getAvatarImageUrl(user.id)} />
                   </ListItemAvatar>
                   <ListItemText primary={user.name} />
                 </ListItem>

--- a/frontend/components/chat/friend/FriendInfoDialog.tsx
+++ b/frontend/components/chat/friend/FriendInfoDialog.tsx
@@ -12,6 +12,7 @@ import {
   FormControl,
 } from '@mui/material';
 import { Friend } from 'types/friend';
+import Link from 'next/link';
 
 type Props = {
   friend: Friend;
@@ -59,7 +60,9 @@ export const FriendInfoDialog = memo(function FriendInfoDialog({
             label="Action"
             onChange={handleChangeType}
           >
-            <MenuItem value="Profile">Profile</MenuItem>
+            <Link href={{ pathname: '/profile', query: { userId: friend.id } }}>
+              <MenuItem value="Profile">Profile</MenuItem>
+            </Link>
             <MenuItem value="Invite Game">Invite Game</MenuItem>
             <MenuItem value="Direct Message">Direct Message</MenuItem>
           </Select>

--- a/frontend/components/chat/friend/FriendListItem.tsx
+++ b/frontend/components/chat/friend/FriendListItem.tsx
@@ -1,10 +1,10 @@
 import { useState, memo } from 'react';
 import { ListItem, ListItemText, ListItemAvatar, Avatar } from '@mui/material';
-import { blue } from '@mui/material/colors';
 import { Friend } from 'types/friend';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { FriendInfoDialog } from 'components/chat/friend/FriendInfoDialog';
 import { Loading } from 'components/common/Loading';
+import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
 
 type Props = {
   friend: Friend;
@@ -29,7 +29,7 @@ export const FriendListItem = memo(function FriendListItem({ friend }: Props) {
     <>
       <ListItem divider button onClick={handleClickOpen}>
         <ListItemAvatar>
-          <Avatar sx={{ bgcolor: blue[100], color: blue[600] }} />
+          <Avatar src={getAvatarImageUrl(friend.id)} />
         </ListItemAvatar>
         <ListItemText
           primary={friend.name}

--- a/frontend/components/chat/friend/FriendListItem.tsx
+++ b/frontend/components/chat/friend/FriendListItem.tsx
@@ -1,10 +1,18 @@
-import { useState, memo } from 'react';
-import { ListItem, ListItemText, ListItemAvatar, Avatar } from '@mui/material';
+import { useState, memo, useEffect } from 'react';
+import {
+  ListItem,
+  ListItemText,
+  ListItemAvatar,
+  Avatar,
+  Badge,
+} from '@mui/material';
 import { Friend } from 'types/friend';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { FriendInfoDialog } from 'components/chat/friend/FriendInfoDialog';
 import { Loading } from 'components/common/Loading';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
+import { getUserStatusById } from 'api/user/getUserStatusById';
+import { UserStatus } from '@prisma/client';
 
 type Props = {
   friend: Friend;
@@ -12,10 +20,23 @@ type Props = {
 
 export const FriendListItem = memo(function FriendListItem({ friend }: Props) {
   const [open, setOpen] = useState(false);
+  const [friendStatus, setFriendStatus] = useState<UserStatus>('OFFLINE');
   const { data: user } = useQueryUser();
   if (user === undefined) {
     return <Loading />;
   }
+
+  useEffect(() => {
+    const updateStatus = async () => {
+      const fetchedStatus = await getUserStatusById({ userId: friend.id });
+      console.log(fetchedStatus);
+      setFriendStatus(fetchedStatus);
+    };
+
+    updateStatus().catch((err) => {
+      console.error(err);
+    });
+  }, []);
 
   const handleClickOpen = () => {
     setOpen(true);
@@ -29,7 +50,20 @@ export const FriendListItem = memo(function FriendListItem({ friend }: Props) {
     <>
       <ListItem divider button onClick={handleClickOpen}>
         <ListItemAvatar>
-          <Avatar src={getAvatarImageUrl(friend.id)} />
+          <Badge
+            overlap="circular"
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            badgeContent=""
+            color={
+              friendStatus === 'ONLINE'
+                ? 'success'
+                : friendStatus === 'PLAYING'
+                ? 'error'
+                : 'default'
+            }
+          >
+            <Avatar src={getAvatarImageUrl(friend.id)} />
+          </Badge>
         </ListItemAvatar>
         <ListItemText
           primary={friend.name}

--- a/frontend/components/common/MenuButton.tsx
+++ b/frontend/components/common/MenuButton.tsx
@@ -25,17 +25,22 @@ export const MenuButton = () => {
   const router = useRouter();
   const { data: user } = useQueryUser();
 
+  if (user === undefined) return <Loading />;
+
   const logout = () => {
+    void axios.post(
+      `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
+      {
+        id: user.id,
+      },
+    );
     queryClient.removeQueries(['user']);
-    void axios.post(`${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`);
     if (session) {
       void signOut();
     } else {
       void router.push('/');
     }
   };
-
-  if (user === undefined) return <Loading />;
 
   return (
     <div>

--- a/frontend/components/game/home/Start.tsx
+++ b/frontend/components/game/home/Start.tsx
@@ -14,6 +14,7 @@ export const Start = () => {
 
   const start = () => {
     socket.emit('playStart', user.id);
+    user.status = 'PLAYING';
     updatePlayState(PlayState.stateWaiting);
   };
 

--- a/frontend/components/game/home/Start.tsx
+++ b/frontend/components/game/home/Start.tsx
@@ -14,7 +14,6 @@ export const Start = () => {
 
   const start = () => {
     socket.emit('playStart', user.id);
-    user.status = 'PLAYING';
     updatePlayState(PlayState.stateWaiting);
   };
 

--- a/frontend/hooks/useQueryUser.tsx
+++ b/frontend/hooks/useQueryUser.tsx
@@ -22,10 +22,16 @@ export const useQueryUser = () => {
         err.response &&
         (err.response.status === 401 || err.response.status === 403)
       ) {
-        queryClient.removeQueries(['user']);
-        void axios.post(
-          `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
-        );
+        const user: User | undefined = queryClient.getQueryData(['user']);
+        if (user !== undefined) {
+          void axios.post(
+            `${process.env.NEXT_PUBLIC_API_URL as string}/auth/logout`,
+            {
+              id: user.id,
+            },
+          );
+          queryClient.removeQueries(['user']);
+        }
         void router.push('/');
       }
     },

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -1,4 +1,11 @@
-import { Avatar, Grid, Typography, Alert, AlertTitle } from '@mui/material';
+import {
+  Avatar,
+  Grid,
+  Typography,
+  Alert,
+  AlertTitle,
+  Badge,
+} from '@mui/material';
 import { Header } from 'components/common/Header';
 import { Layout } from 'components/common/Layout';
 import { Loading } from 'components/common/Loading';
@@ -60,7 +67,20 @@ const Profile: NextPage = () => {
         sx={{ p: 2 }}
       >
         <Grid item>
-          <Avatar sx={{ width: 150, height: 150 }} src={avatarImageUrl} />
+          <Badge
+            overlap="circular"
+            anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+            badgeContent=""
+            color={
+              user.status === 'ONLINE'
+                ? 'success'
+                : user.status === 'PLAYING'
+                ? 'error'
+                : 'default'
+            }
+          >
+            <Avatar sx={{ width: 150, height: 150 }} src={avatarImageUrl} />
+          </Badge>
         </Grid>
         <Grid item>
           <Typography gutterBottom variant="h1" component="div">

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -87,6 +87,7 @@ model User {
   hashedPassword  String?
   point           Int               @default(1000)
   avatarPath      String?
+  status          UserStatus        @default(OFFLINE)
   Chatroom        Chatroom[]
   ChatroomAdmin   ChatroomAdmin[]
   ChatroomMembers ChatroomMembers[]
@@ -101,4 +102,10 @@ enum ChatroomType {
   PUBLIC
   PRIVATE
   PROTECTED
+}
+
+enum UserStatus {
+  ONLINE
+  PLAYING
+  OFFLINE
 }


### PR DESCRIPTION
## 概要

- チャット画面の友達リストからProfileを選択するとそのユーザーのプロフィールに飛ぶようにしました
- チャット画面の友達リスト、及び、プロフィール画面において、アバターの右下にステータスを表示させるようにしました
    - ログイン中: 緑の丸を表示
    - ログアウト中: 何も表示しない
    - ゲーム中、または、ゲームの観戦中: 赤の丸を表示 (※この部分は未実装です)

## 今後の実装予定

- ゲームを開始したり、試合観戦を開始したタイミングで、ステータスを変更する機能を実装
(#165 )
- ステータスの変更が起きた際に、チャットの友達リストのステータスが更新される機能をsocket.ioを使って実装
(#166 )

## 関連イシュー

- resolve #139 
- resolve #143 
- resolve #152 