### PR TITLE
チャットルームオーナーがAdminを設定できるようにした

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -1,0 +1,24 @@
+import { Query, Controller, Get, ParseIntPipe } from '@nestjs/common';
+import { ChatService } from './chat.service';
+import type { ChatUser } from './types/chat';
+
+@Controller('chat')
+export class ChatController {
+  constructor(private readonly chatService: ChatService) {}
+
+  /**
+   * @param userId
+   * @param roomId
+   * @return 以下の情報をオブジェクトの配列で返す
+   * - adminではないユーザーのID
+   * - adminではないユーザーの名前
+   */
+  @Get('non-admin')
+  async findNotAdminUsers(
+    @Query('roomId', ParseIntPipe) roomId: number,
+  ): Promise<ChatUser[]> {
+    console.log('non-admin:', roomId);
+
+    return await this.chatService.findNotAdminUsers(roomId);
+  }
+}

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -7,7 +7,6 @@ export class ChatController {
   constructor(private readonly chatService: ChatService) {}
 
   /**
-   * @param userId
    * @param roomId
    * @return 以下の情報をオブジェクトの配列で返す
    * - adminではないユーザーのID
@@ -17,8 +16,6 @@ export class ChatController {
   async findNotAdminUsers(
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<ChatUser[]> {
-    console.log('non-admin:', roomId);
-
     return await this.chatService.findNotAdminUsers(roomId);
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -13,6 +13,7 @@ import { CreateChatroomDto } from './dto/create-chatroom.dto';
 import { DeleteChatroomDto } from './dto/delete-chatroom.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
+import { CreateAdminDto } from './dto/create-admin.dto';
 import { Chatroom, ChatroomType } from '@prisma/client';
 
 @WebSocketGateway({
@@ -245,5 +246,24 @@ export class ChatGateway {
 
     // フロントエンドへ送信し返す
     client.emit('chat:getJoinableRooms', viewableAndNotJoinedRooms);
+  }
+
+  /**
+   * ユーザーをAdminに追加する
+   * @param userId
+   * @param roomId
+   */
+  @SubscribeMessage('chat:addAdmin')
+  async addAdmin(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: CreateAdminDto,
+  ): Promise<boolean> {
+    this.logger.log(
+      `chat:getJoinableRooms received -> roomId: ${dto.chatroomId}`,
+    );
+
+    const res = await this.chatService.createAdmin(dto);
+
+    return res !== undefined;
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -258,12 +258,29 @@ export class ChatGateway {
     @ConnectedSocket() client: Socket,
     @MessageBody() dto: CreateAdminDto,
   ): Promise<boolean> {
-    this.logger.log(
-      `chat:getJoinableRooms received -> roomId: ${dto.chatroomId}`,
-    );
+    this.logger.log(`chat:addAdmin received -> roomId: ${dto.chatroomId}`);
 
     const res = await this.chatService.createAdmin(dto);
 
     return res !== undefined;
+  }
+
+  /**
+   * チャットルームのadminId一覧を返す
+   * @param roomId
+   */
+  @SubscribeMessage('chat:getAdminIds')
+  async getAdmins(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() roomId: number,
+  ): Promise<number[]> {
+    this.logger.log(`chat:getAdmins received -> roomId: ${roomId}`);
+
+    const admins = await this.chatService.findAdmins(roomId);
+    const res = admins.map((admin) => {
+      return admin.userId;
+    });
+
+    return res;
   }
 }

--- a/backend/src/chat/chat.module.ts
+++ b/backend/src/chat/chat.module.ts
@@ -1,9 +1,11 @@
 import { Module } from '@nestjs/common';
 import { ChatGateway } from './chat.gateway';
 import { ChatService } from './chat.service';
+import { ChatController } from './chat.controller';
 import { PrismaService } from '../prisma.service';
 
 @Module({
+  controllers: [ChatController],
   providers: [ChatGateway, ChatService, PrismaService],
 })
 export class ChatModule {}

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -10,6 +10,7 @@ import {
 } from '@prisma/client';
 import { CreateChatroomDto } from './dto/create-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
+import { CreateAdminDto } from './dto/create-admin.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import type { ChatUser } from './types/chat';
 
@@ -247,8 +248,25 @@ export class ChatService {
         name: info.user.name,
       };
     });
-    console.log(notAdminUsers);
 
     return notAdminUsers;
+  }
+
+  /**
+   * チャットルームのadminを作成する
+   * @param CreateAdminDto
+   */
+  async createAdmin(dto: CreateAdminDto): Promise<ChatroomAdmin> {
+    try {
+      const admin = await this.prisma.chatroomAdmin.create({
+        data: {
+          ...dto,
+        },
+      });
+
+      return admin;
+    } catch (error) {
+      return undefined;
+    }
   }
 }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -11,6 +11,7 @@ import {
 import { CreateChatroomDto } from './dto/create-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
+import type { ChatUser } from './types/chat';
 
 @Injectable()
 export class ChatService {
@@ -204,5 +205,50 @@ export class ChatService {
 
     // 入室できたら作成したチャットルームの情報を返す
     return isSuccess ? createdRoom : undefined;
+  }
+
+  /**
+   * 所属している かつ adminではないユーザ一覧を返す
+   * @param userId
+   * @param roomId
+   */
+  async findNotAdminUsers(roomId: number): Promise<ChatUser[]> {
+    // ルームに所属しているユーザー一覧を取得する
+    const joinedUsersInfo = await this.prisma.chatroomMembers.findMany({
+      where: {
+        chatroomId: roomId,
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    // ルームのadmin一覧を取得する
+    const adminUsers = await this.prisma.chatroomAdmin.findMany({
+      where: {
+        chatroomId: roomId,
+      },
+    });
+
+    // idの配列にする
+    const adminUserIds = adminUsers.map((admin) => {
+      return admin.userId;
+    });
+
+    // adminのユーザー除去する
+    const notAdminUsersInfo = joinedUsersInfo.filter(
+      (info) => !adminUserIds.includes(info.user.id),
+    );
+
+    // idと名前の配列にする
+    const notAdminUsers: ChatUser[] = notAdminUsersInfo.map((info) => {
+      return {
+        id: info.user.id,
+        name: info.user.name,
+      };
+    });
+    console.log(notAdminUsers);
+
+    return notAdminUsers;
   }
 }

--- a/backend/src/chat/dto/create-admin.dto.ts
+++ b/backend/src/chat/dto/create-admin.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CreateAdminDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+}

--- a/backend/src/chat/types/chat.ts
+++ b/backend/src/chat/types/chat.ts
@@ -1,0 +1,4 @@
+export type ChatUser = {
+  id: number;
+  name: string;
+};

--- a/frontend/api/chat/fetchNotAdminUsers.ts
+++ b/frontend/api/chat/fetchNotAdminUsers.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { ChatUser } from 'types/chat';
+
+type Props = {
+  roomId: number;
+};
+
+const endpoint = `${process.env.NEXT_PUBLIC_API_URL as string}/chat/non-admin`;
+
+export const fetchNotAdminUsers = async ({ roomId }: Props) => {
+  try {
+    const response = await axios.get<ChatUser[]>(endpoint, {
+      params: { roomId: roomId },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+
+    return [];
+  }
+};

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -45,10 +45,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
 
   const [warning, setWarning] = useState(false);
   const deleteRoom = () => {
-    console.log('deleteRoom:', room.id);
-
-    // TODO: adminのハンドリングもチェックする
-    // TODO: そもそも削除ボタンを表示しない
+    // 削除できるのはチャットルームオーナーだけ
     if (user.id !== room.ownerId) {
       setWarning(true);
     } else {
@@ -60,18 +57,29 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     }
   };
 
+  // friendをチャットルームに追加する
   const addFriend = (friendId: number) => {
-    console.log();
-    // フレンドを選択する
     const joinRoomInfo: JoinChatroomInfo = {
       userId: friendId,
       roomId: room.id,
       type: room.type as ChatroomType,
     };
 
-    // friendをチャットルームに追加する
     // TODO:フレンドを入室させたあとのgatewayからのレスポンス対応は今後行う
     socket.emit('chat:joinRoom', joinRoomInfo);
+  };
+
+  const addAdmin = (userId: number) => {
+    // Adminを設定できるのはチャットルームオーナーだけ
+    if (user.id !== room.ownerId) {
+      setWarning(true);
+    } else {
+      const setAdminInfo = {
+        userId: userId,
+        roomId: room.id,
+      };
+      socket.emit('chat:addAdmin', setAdminInfo);
+    }
   };
 
   return (
@@ -119,6 +127,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             onClose={handleClose}
             deleteRoom={deleteRoom}
             addFriend={addFriend}
+            addAdmin={addAdmin}
           />
           <ListItemText
             primary={room.name}

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import {
   ListItem,
   IconButton,
@@ -23,7 +23,22 @@ type Props = {
 
 export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const [open, setOpen] = useState(false);
+  const [isAdmin, setIsAdmin] = useState(false);
   const { data: user } = useQueryUser();
+
+  useEffect(() => {
+    if (!user) return;
+
+    // adminかどうかを判定する
+    socket.emit('chat:getAdminIds', room.id, (adminIds: number[]) => {
+      console.log('adminIds', adminIds);
+      adminIds.map((id) => {
+        if (id === user.id) {
+          setIsAdmin(true);
+        }
+      });
+    });
+  }, [user]);
 
   if (user === undefined) {
     return <Loading />;
@@ -112,8 +127,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
           </Alert>
         </Collapse>
       </Box>
-      {/* TODO: 一旦ルーム作成者のみに設定ボタンが表示されるようにしている */}
-      {user.id === room.ownerId ? (
+      {user.id === room.ownerId || isAdmin ? (
         <ListItem
           secondaryAction={
             <IconButton

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -76,9 +76,15 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     } else {
       const setAdminInfo = {
         userId: userId,
-        roomId: room.id,
+        chatroomId: room.id,
       };
-      socket.emit('chat:addAdmin', setAdminInfo);
+
+      // callbackを受け取ることで判断する
+      socket.emit('chat:addAdmin', setAdminInfo, (res: boolean) => {
+        if (!res) {
+          setWarning(true);
+        }
+      });
     }
   };
 
@@ -102,7 +108,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             }
             sx={{ mb: 2 }}
           >
-            {room.name} could not be deleted.
+            {room.name} failed to process.
           </Alert>
         </Collapse>
       </Box>

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -43,7 +43,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
 }: Props) {
   const { data: user } = useQueryUser();
   const [selectedRoomSetting, setSelectedRoomSetting] =
-    useState<ChatroomSettings>(CHATROOM_SETTINGS.DELETE_ROOM);
+    useState<ChatroomSettings>(CHATROOM_SETTINGS.MUTE_USER);
   const [selectedUserId, setSelectedUserId] = useState('');
   const [notAdminUsers, setNotAdminUsers] = useState<ChatUser[]>([]);
   const [friends, setFriends] = useState<Friend[]>([]);

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -16,9 +16,11 @@ import {
   ChatroomSettings,
   CHATROOM_SETTINGS,
   CHATROOM_TYPE,
+  ChatUser,
 } from 'types/chat';
 import { Friend } from 'types/friend';
 import { fetchJoinableFriends } from 'api/friend/fetchJoinableFriends';
+import { fetchNotAdminUsers } from 'api/chat/fetchNotAdminUsers';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 
@@ -28,6 +30,7 @@ type Props = {
   onClose: () => void;
   deleteRoom: () => void;
   addFriend: (friendId: number) => void;
+  addAdmin: (userId: number) => void;
 };
 
 export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
@@ -36,17 +39,19 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   onClose,
   deleteRoom,
   addFriend,
+  addAdmin,
 }: Props) {
   const { data: user } = useQueryUser();
   const [selectedRoomSetting, setSelectedRoomSetting] =
     useState<ChatroomSettings>(CHATROOM_SETTINGS.DELETE_ROOM);
-  const [selectedFriendId, setSelectedFriendId] = useState('');
+  const [selectedUserId, setSelectedUserId] = useState('');
+  const [notAdminUsers, setNotAdminUsers] = useState<ChatUser[]>([]);
   const [friends, setFriends] = useState<Friend[]>([]);
 
   useEffect(() => {
     if (user === undefined) return;
     // フレンドを追加する項目を選択時に取得する
-    if (selectedRoomSetting === CHATROOM_SETTINGS.ADD_FRIEND) return;
+    if (selectedRoomSetting !== CHATROOM_SETTINGS.ADD_FRIEND) return;
 
     const fetchFriends = async () => {
       // フォローしている かつ そのチャットルームに所属していないユーザーを取得する
@@ -58,13 +63,30 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       setFriends(res);
     };
 
-    fetchFriends()
-      .then((res) => {
-        console.log(res);
-      })
-      .catch((err) => {
-        console.log(err);
+    void fetchFriends();
+  }, [selectedRoomSetting]);
+
+  useEffect(() => {
+    if (user === undefined) return;
+    // Adminを追加する項目を選択時に取得する
+    if (selectedRoomSetting !== CHATROOM_SETTINGS.SET_ADMIN) return;
+
+    const fetchCanSetAdminUsers = async () => {
+      // チャットルーム入室している かつ すでにAdminではない ユーザーを取得する
+      const notAdminUsers = await fetchNotAdminUsers({
+        roomId: room.id,
       });
+      console.log(notAdminUsers);
+      console.log(user.id);
+      // オーナーを弾く
+      const expectOwner = notAdminUsers.filter(
+        (notAdmin) => notAdmin.id !== user.id,
+      );
+      console.log(expectOwner);
+      setNotAdminUsers(expectOwner);
+    };
+
+    void fetchCanSetAdminUsers();
   }, [selectedRoomSetting]);
 
   if (user === undefined) {
@@ -73,7 +95,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
 
   const initDialog = () => {
     setSelectedRoomSetting(CHATROOM_SETTINGS.DELETE_ROOM);
-    setSelectedFriendId('');
+    setSelectedUserId('');
   };
 
   const handleClose = () => {
@@ -86,25 +108,23 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     setSelectedRoomSetting(event.target.value as ChatroomSettings);
   };
 
-  const handleChangeFriend = (event: SelectChangeEvent) => {
-    setSelectedFriendId(event.target.value);
+  const handleChangeUserId = (event: SelectChangeEvent) => {
+    setSelectedUserId(event.target.value);
   };
 
   const handleAction = () => {
     switch (selectedRoomSetting) {
       case CHATROOM_SETTINGS.DELETE_ROOM:
         deleteRoom();
-        console.log(selectedRoomSetting);
         break;
       case CHATROOM_SETTINGS.ADD_FRIEND:
-        addFriend(Number(selectedFriendId));
-        console.log(selectedRoomSetting);
+        addFriend(Number(selectedUserId));
         break;
       case CHATROOM_SETTINGS.CHANGE_PASSWORD:
         console.log(selectedRoomSetting);
         break;
       case CHATROOM_SETTINGS.SET_ADMIN:
-        console.log(selectedRoomSetting);
+        addAdmin(Number(selectedUserId));
         break;
       case CHATROOM_SETTINGS.MUTE_USER:
         console.log(selectedRoomSetting);
@@ -115,6 +135,8 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     }
     handleClose();
   };
+
+  const isOwner = room.ownerId === user.id;
 
   return (
     <>
@@ -130,26 +152,33 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
               label="setting"
               onChange={handleChangeSetting}
             >
-              <MenuItem value={CHATROOM_SETTINGS.DELETE_ROOM}>
-                {CHATROOM_SETTINGS.DELETE_ROOM}
-              </MenuItem>
-              <MenuItem value={CHATROOM_SETTINGS.SET_ADMIN}>
-                {CHATROOM_SETTINGS.SET_ADMIN}
-              </MenuItem>
+              {isOwner && (
+                <MenuItem value={CHATROOM_SETTINGS.DELETE_ROOM}>
+                  {CHATROOM_SETTINGS.DELETE_ROOM}
+                </MenuItem>
+              )}
+              {isOwner && (
+                <MenuItem value={CHATROOM_SETTINGS.SET_ADMIN}>
+                  {CHATROOM_SETTINGS.SET_ADMIN}
+                </MenuItem>
+              )}
+              {isOwner && (
+                <MenuItem value={CHATROOM_SETTINGS.CHANGE_PASSWORD}>
+                  {CHATROOM_SETTINGS.CHANGE_PASSWORD}
+                </MenuItem>
+              )}
+              {/* 非公開のルームのみフレンド追加ボタンが選択可能 */}
+              {isOwner && room.type === CHATROOM_TYPE.PRIVATE && (
+                <MenuItem value={CHATROOM_SETTINGS.ADD_FRIEND}>
+                  {CHATROOM_SETTINGS.ADD_FRIEND}
+                </MenuItem>
+              )}
+              {/* 以下はAdminも設定可能な項目 */}
               <MenuItem value={CHATROOM_SETTINGS.MUTE_USER}>
                 {CHATROOM_SETTINGS.MUTE_USER}
               </MenuItem>
               <MenuItem value={CHATROOM_SETTINGS.BAN_USER}>
                 {CHATROOM_SETTINGS.BAN_USER}
-              </MenuItem>
-              {/* 非公開のルームのみフレンドを追加ボタンが選択可能 */}
-              {room.type === CHATROOM_TYPE.PRIVATE && (
-                <MenuItem value={CHATROOM_SETTINGS.ADD_FRIEND}>
-                  {CHATROOM_SETTINGS.ADD_FRIEND}
-                </MenuItem>
-              )}
-              <MenuItem value={CHATROOM_SETTINGS.CHANGE_PASSWORD}>
-                {CHATROOM_SETTINGS.CHANGE_PASSWORD}
               </MenuItem>
             </Select>
           </FormControl>
@@ -170,13 +199,44 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
                   <Select
                     labelId="room-setting-select-label"
                     id="room-setting"
-                    value={selectedFriendId}
+                    value={selectedUserId}
                     label="setting"
-                    onChange={handleChangeFriend}
+                    onChange={handleChangeUserId}
                   >
                     {friends.map((friend) => (
                       <MenuItem value={String(friend.id)} key={friend.id}>
                         {friend.name}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </DialogContent>
+            )}
+          </>
+        )}
+        {selectedRoomSetting === CHATROOM_SETTINGS.SET_ADMIN && (
+          <>
+            {notAdminUsers.length === 0 ? (
+              <div
+                className="mb-4 flex justify-center rounded-lg bg-red-100 p-4 text-sm text-red-700 dark:bg-red-200 dark:text-red-800"
+                role="alert"
+              >
+                <span className="font-medium">No users are available.</span>
+              </div>
+            ) : (
+              <DialogContent>
+                <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
+                  <InputLabel id="room-setting-select-label">User</InputLabel>
+                  <Select
+                    labelId="room-setting-select-label"
+                    id="room-setting"
+                    value={selectedUserId}
+                    label="setting"
+                    onChange={handleChangeUserId}
+                  >
+                    {notAdminUsers.map((notAdmin) => (
+                      <MenuItem value={String(notAdmin.id)} key={notAdmin.id}>
+                        {notAdmin.name}
                       </MenuItem>
                     ))}
                   </Select>

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -45,3 +45,8 @@ export const CHATROOM_SETTINGS = {
 
 export type ChatroomSettings =
   typeof CHATROOM_SETTINGS[keyof typeof CHATROOM_SETTINGS];
+
+export type ChatUser = {
+  id: number;
+  name: string;
+};


### PR DESCRIPTION
## 概要
- チャットルームオーナーがAdminを設定可能にした
- Adminに設定可能な対象は、そのチャットルームに所属しているユーザー

## 動作確認
- user1, user2を作成する
- user1でroomを作成する
- user2を入室させる
- user1でuser2をadminに設定する
- user2はmute userとbun userのみ選択できるようになる

## その他
- 似た処理が増えてきたので今後共通化するかも

## 関連issue
- resolve #161 
