### PR TITLE
Protectedルームのパスワードを変更できるようにした

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -14,6 +14,7 @@ import { DeleteChatroomDto } from './dto/delete-chatroom.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { CreateAdminDto } from './dto/create-admin.dto';
+import { updatePasswordDto } from './dto/update-password.dto';
 import { Chatroom, ChatroomType } from '@prisma/client';
 
 @WebSocketGateway({
@@ -270,7 +271,7 @@ export class ChatGateway {
    * @param roomId
    */
   @SubscribeMessage('chat:getAdminIds')
-  async getAdmins(
+  async getAdminsIds(
     @ConnectedSocket() client: Socket,
     @MessageBody() roomId: number,
   ): Promise<number[]> {
@@ -282,5 +283,23 @@ export class ChatGateway {
     });
 
     return res;
+  }
+
+  /**
+   * チャットルームのパスワードを更新する
+   * @param updatePasswordDto
+   */
+  @SubscribeMessage('chat:updatePassword')
+  async updatePassword(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: updatePasswordDto,
+  ): Promise<boolean> {
+    this.logger.log(
+      `chat:updatePassword received -> roomId: ${dto.chatroomId}`,
+    );
+
+    console.log('dto:', dto);
+
+    return await this.chatService.updatePassword(dto);
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -298,8 +298,6 @@ export class ChatGateway {
       `chat:updatePassword received -> roomId: ${dto.chatroomId}`,
     );
 
-    console.log('dto:', dto);
-
     return await this.chatService.updatePassword(dto);
   }
 }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -164,7 +164,9 @@ export class ChatService {
         id: dto.roomId,
       },
     });
-    if (!chatroom) return undefined;
+    if (!chatroom) {
+      return undefined;
+    }
 
     if (dto.type === ChatroomType.PROTECTED) {
       // Protectedの場合はパスワードが正しいことを確認する
@@ -172,7 +174,9 @@ export class ChatService {
         dto.password,
         chatroom.hashedPassword,
       );
-      if (!isValid) return undefined;
+      if (!isValid) {
+        return undefined;
+      }
     }
 
     // 入室処理を行う
@@ -291,19 +295,25 @@ export class ChatService {
       dto.oldPassword,
       targetRoom.hashedPassword,
     );
-    if (!isValid) return false;
+    if (!isValid) {
+      return false;
+    }
 
     const hashed = await bcrypt.hash(dto.newPassword, saltRounds);
 
-    const res = this.update({
-      data: {
-        hashedPassword: hashed,
-      },
-      where: {
-        id: dto.chatroomId,
-      },
-    });
+    try {
+      await this.update({
+        data: {
+          hashedPassword: hashed,
+        },
+        where: {
+          id: dto.chatroomId,
+        },
+      });
 
-    return res !== undefined;
+      return true;
+    } catch (err) {
+      return false;
+    }
   }
 }

--- a/backend/src/chat/dto/update-password.dto.ts
+++ b/backend/src/chat/dto/update-password.dto.ts
@@ -1,0 +1,15 @@
+import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+
+export class updatePasswordDto {
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  oldPassword: string;
+
+  @IsString()
+  @IsNotEmpty()
+  newPassword: string;
+}

--- a/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
@@ -221,7 +221,7 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
             onClick={handleSubmit(onSubmit) as VoidFunction}
             variant="contained"
           >
-            Submit
+            Create
           </Button>
         </DialogActions>
       </Dialog>

--- a/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
@@ -52,7 +52,7 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
       (value: string) =>
         roomType !== CHATROOM_TYPE.PROTECTED || value.length >= 5,
       () => ({
-        message: 'Password passwords must be at least 5 characters',
+        message: 'Passwords must be at least 5 characters',
       }),
     ),
   });
@@ -100,12 +100,6 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
   );
 
   const onSubmit: SubmitHandler<ChatroomForm> = (data: ChatroomForm) => {
-    if (roomType === CHATROOM_TYPE.PROTECTED && data.password.length === 0) {
-      handleClose();
-
-      return;
-    }
-
     const room: CreateChatroomInfo = {
       name: data.roomName,
       type: roomType,

--- a/frontend/components/chat/chatroom/ChatroomJoinButton.tsx
+++ b/frontend/components/chat/chatroom/ChatroomJoinButton.tsx
@@ -2,7 +2,6 @@ import { memo, useState, useCallback, useEffect } from 'react';
 import { Socket } from 'socket.io-client';
 import { Button } from '@mui/material';
 import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded';
-import { CHATROOM_TYPE } from 'types/chat';
 import { User, Chatroom } from '@prisma/client';
 import { ChatroomJoinDialog } from 'components/chat/chatroom/ChatroomJoinDialog';
 

--- a/frontend/components/chat/chatroom/ChatroomJoinDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomJoinDialog.tsx
@@ -108,6 +108,7 @@ export const ChatroomJoinDialog = memo(function ChatroomJoinDialog({
         socket.emit('chat:getJoinedRooms', user.id);
       } else {
         setError('Incorrect password.');
+        reset();
       }
     });
 

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -14,6 +14,7 @@ import { Chatroom, ChatroomType, JoinChatroomInfo } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 import { ChatroomSettingDialog } from 'components/chat/chatroom/ChatroomSettingDialog';
+import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
 
 type Props = {
   room: Chatroom;
@@ -132,24 +133,10 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     <>
       <Box sx={{ width: '100%' }}>
         <Collapse in={error !== ''}>
-          <Alert
-            severity="error"
-            action={
-              <IconButton
-                aria-label="close"
-                color="inherit"
-                size="small"
-                onClick={() => {
-                  setError('');
-                }}
-              >
-                <CloseIcon fontSize="inherit" />
-              </IconButton>
-            }
-            sx={{ mb: 2 }}
-          >
-            {`${room.name}: ${error}`}
-          </Alert>
+          <ChatErrorAlert
+            error={`${room.name}: ${error}`}
+            setError={setError}
+          />
         </Collapse>
       </Box>
       <Box sx={{ width: '100%' }}>

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -59,11 +59,11 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     setOpen(false);
   };
 
-  const [warning, setWarning] = useState(false);
+  const [error, setError] = useState('');
   const deleteRoom = () => {
     // 削除できるのはチャットルームオーナーだけ
     if (user.id !== room.ownerId) {
-      setWarning(true);
+      setError('Only the owner can delete chat rooms');
     } else {
       const deleteRoomInfo = {
         id: room.id,
@@ -88,7 +88,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const addAdmin = (userId: number) => {
     // Adminを設定できるのはチャットルームオーナーだけ
     if (user.id !== room.ownerId) {
-      setWarning(true);
+      setError('Only the owner can set admin');
     } else {
       const setAdminInfo = {
         userId: userId,
@@ -98,7 +98,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
       // callbackを受け取ることで判断する
       socket.emit('chat:addAdmin', setAdminInfo, (res: boolean) => {
         if (!res) {
-          setWarning(true);
+          setError('Failed to add admin');
         }
       });
     }
@@ -110,8 +110,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     checkPassword: string,
   ) => {
     if (newPassword !== checkPassword) {
-      // 新しいパスワードとチェック用パスワードが違う
-      setWarning(true);
+      setError('Check passwords did not match');
 
       return;
     }
@@ -124,7 +123,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
       if (res) {
         setChangeSuccess(true);
       } else {
-        setWarning(true);
+        setError('Failed to change password');
       }
     });
   };
@@ -132,7 +131,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   return (
     <>
       <Box sx={{ width: '100%' }}>
-        <Collapse in={warning}>
+        <Collapse in={error !== ''}>
           <Alert
             severity="error"
             action={
@@ -141,7 +140,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
                 color="inherit"
                 size="small"
                 onClick={() => {
-                  setWarning(false);
+                  setError('');
                 }}
               >
                 <CloseIcon fontSize="inherit" />
@@ -149,7 +148,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             }
             sx={{ mb: 2 }}
           >
-            {room.name} failed to process.
+            {`${room.name}: ${error}`}
           </Alert>
         </Collapse>
       </Box>

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -24,6 +24,7 @@ type Props = {
 export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const [open, setOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
+  const [changeSuccess, setChangeSuccess] = useState(false);
   const { data: user } = useQueryUser();
 
   useEffect(() => {
@@ -103,6 +104,31 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     }
   };
 
+  const changePassword = (
+    oldPassword: string,
+    newPassword: string,
+    checkPassword: string,
+  ) => {
+    if (newPassword !== checkPassword) {
+      // 新しいパスワードとチェック用パスワードが違う
+      setWarning(true);
+
+      return;
+    }
+    const changePasswordInfo = {
+      chatroomId: room.id,
+      oldPassword: oldPassword,
+      newPassword: newPassword,
+    };
+    socket.emit('chat:updatePassword', changePasswordInfo, (res: boolean) => {
+      if (res) {
+        setChangeSuccess(true);
+      } else {
+        setWarning(true);
+      }
+    });
+  };
+
   return (
     <>
       <Box sx={{ width: '100%' }}>
@@ -127,6 +153,28 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
           </Alert>
         </Collapse>
       </Box>
+      <Box sx={{ width: '100%' }}>
+        <Collapse in={changeSuccess}>
+          <Alert
+            severity="success"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setChangeSuccess(false);
+                }}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+            sx={{ mb: 2 }}
+          >
+            {room.name} password changed.
+          </Alert>
+        </Collapse>
+      </Box>
       {user.id === room.ownerId || isAdmin ? (
         <ListItem
           secondaryAction={
@@ -148,6 +196,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             deleteRoom={deleteRoom}
             addFriend={addFriend}
             addAdmin={addAdmin}
+            changePassword={changePassword}
           />
           <ListItemText
             primary={room.name}

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -10,6 +10,7 @@ import {
   MenuItem,
   FormControl,
   DialogTitle,
+  TextField,
 } from '@mui/material';
 import {
   Chatroom,
@@ -31,6 +32,11 @@ type Props = {
   deleteRoom: () => void;
   addFriend: (friendId: number) => void;
   addAdmin: (userId: number) => void;
+  changePassword: (
+    oldPassword: string,
+    newPassword: string,
+    checkPassword: string,
+  ) => void;
 };
 
 export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
@@ -40,6 +46,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   deleteRoom,
   addFriend,
   addAdmin,
+  changePassword,
 }: Props) {
   const { data: user } = useQueryUser();
   const [selectedRoomSetting, setSelectedRoomSetting] =
@@ -47,6 +54,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   const [selectedUserId, setSelectedUserId] = useState('');
   const [notAdminUsers, setNotAdminUsers] = useState<ChatUser[]>([]);
   const [friends, setFriends] = useState<Friend[]>([]);
+
+  const [oldPassword, setOldPassword] = useState('');
+  const [newPassword, setNewPassword] = useState('');
+  const [checkPassword, setCheckPassword] = useState('');
 
   useEffect(() => {
     if (user === undefined) return;
@@ -76,13 +87,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       const notAdminUsers = await fetchNotAdminUsers({
         roomId: room.id,
       });
-      console.log(notAdminUsers);
-      console.log(user.id);
       // オーナーを弾く
       const expectOwner = notAdminUsers.filter(
         (notAdmin) => notAdmin.id !== user.id,
       );
-      console.log(expectOwner);
       setNotAdminUsers(expectOwner);
     };
 
@@ -121,7 +129,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         addFriend(Number(selectedUserId));
         break;
       case CHATROOM_SETTINGS.CHANGE_PASSWORD:
-        console.log(selectedRoomSetting);
+        changePassword(oldPassword, newPassword, checkPassword);
         break;
       case CHATROOM_SETTINGS.SET_ADMIN:
         addAdmin(Number(selectedUserId));
@@ -162,7 +170,8 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
                   {CHATROOM_SETTINGS.SET_ADMIN}
                 </MenuItem>
               )}
-              {isOwner && (
+              {/* パスワードで保護されたルームのみ選択可能 */}
+              {isOwner && room.type === CHATROOM_TYPE.PROTECTED && (
                 <MenuItem value={CHATROOM_SETTINGS.CHANGE_PASSWORD}>
                   {CHATROOM_SETTINGS.CHANGE_PASSWORD}
                 </MenuItem>
@@ -243,6 +252,55 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
                 </FormControl>
               </DialogContent>
             )}
+          </>
+        )}
+        {selectedRoomSetting === CHATROOM_SETTINGS.CHANGE_PASSWORD && (
+          <>
+            <DialogContent>
+              <TextField
+                autoFocus
+                margin="dense"
+                id="old-password"
+                label="Old Password"
+                type="text"
+                value={oldPassword}
+                onChange={(e) => {
+                  setOldPassword(e.target.value);
+                }}
+                fullWidth
+                variant="standard"
+              />
+            </DialogContent>
+            <DialogContent>
+              <TextField
+                autoFocus
+                margin="dense"
+                id="new-password"
+                label="New Password"
+                type="text"
+                value={newPassword}
+                onChange={(e) => {
+                  setNewPassword(e.target.value);
+                }}
+                fullWidth
+                variant="standard"
+              />
+            </DialogContent>
+            <DialogContent>
+              <TextField
+                autoFocus
+                margin="dense"
+                id="check-password"
+                label="Check Password"
+                type="text"
+                value={checkPassword}
+                onChange={(e) => {
+                  setCheckPassword(e.target.value);
+                }}
+                fullWidth
+                variant="standard"
+              />
+            </DialogContent>
           </>
         )}
         <DialogActions>

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -95,6 +95,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       }),
     ),
   });
+  // TODO: 余裕あったら以下を使えるようにする
   // チェック用と新規のパスワードと同じこと
   // .superRefine(({ newPassword, checkPassword }, ctx) => {
   //   if (newPassword !== checkPassword) {
@@ -331,7 +332,6 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
                 control={control}
                 render={({ field }) => (
                   <TextField
-                    autoFocus
                     margin="dense"
                     label="Old Password"
                     type={showPassword ? 'text' : 'password'}
@@ -377,7 +377,6 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
                 control={control}
                 render={({ field }) => (
                   <TextField
-                    autoFocus
                     margin="dense"
                     label="New Password"
                     type={showPassword ? 'text' : 'password'}
@@ -423,7 +422,6 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
                 control={control}
                 render={({ field }) => (
                   <TextField
-                    autoFocus
                     margin="dense"
                     label="Check Password"
                     type={showPassword ? 'text' : 'password'}

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -88,10 +88,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       // オーナーを弾く
-      const expectOwner = notAdminUsers.filter(
+      const exceptOwner = notAdminUsers.filter(
         (notAdmin) => notAdmin.id !== user.id,
       );
-      setNotAdminUsers(expectOwner);
+      setNotAdminUsers(exceptOwner);
     };
 
     void fetchCanSetAdminUsers();

--- a/frontend/components/chat/friend/FriendAddDialog.tsx
+++ b/frontend/components/chat/friend/FriendAddDialog.tsx
@@ -1,9 +1,9 @@
 import { memo, useState, Dispatch, SetStateAction } from 'react';
 import {
-  Alert,
   Avatar,
   Box,
   Button,
+  Collapse,
   List,
   ListItem,
   ListItemAvatar,
@@ -19,6 +19,7 @@ import { Loading } from 'components/common/Loading';
 import { followUser } from 'api/friend/followUser';
 import type { Friend } from 'types/friend';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
+import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
 
 type Props = {
   open: boolean;
@@ -115,7 +116,11 @@ export const FriendAddDialog = memo(function FriendAddDialog({
       {users.length !== 0 && (
         <p className="flex justify-center">Selected: {selectedUser?.name}</p>
       )}
-      {error && <Alert severity="error">{error}</Alert>}
+      <Box sx={{ width: '100%' }}>
+        <Collapse in={error !== ''}>
+          <ChatErrorAlert error={error} setError={setError} />
+        </Collapse>
+      </Box>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         <Button onClick={handleSubmit} disabled={!selectedUser}>

--- a/frontend/components/chat/utils/ChatErrorAlert.tsx
+++ b/frontend/components/chat/utils/ChatErrorAlert.tsx
@@ -1,0 +1,34 @@
+import { memo } from 'react';
+import { IconButton, Alert } from '@mui/material';
+import CloseIcon from '@mui/icons-material/Close';
+
+type Props = {
+  error: string;
+  setError: (error: string) => void;
+};
+
+export const ChatErrorAlert = memo(function ChatErrorAlert({
+  error,
+  setError,
+}: Props) {
+  return (
+    <Alert
+      severity="error"
+      action={
+        <IconButton
+          aria-label="close"
+          color="inherit"
+          size="small"
+          onClick={() => {
+            setError('');
+          }}
+        >
+          <CloseIcon fontSize="inherit" />
+        </IconButton>
+      }
+      sx={{ mb: 2 }}
+    >
+      {error}
+    </Alert>
+  );
+});


### PR DESCRIPTION
## 概要

- Protectedルームのパスワードをチャットルーム作成者が変更できるようにした
- 入力のバリデーションにzodを使うようにした

## その他

- https://github.com/ryo-manba/ft_transcendence/pull/162 がマージされるまで待つ

## 動作確認

Protectedのルームを作成して以下を確認する
- Passwordの文字数が5文字未満の場合エラーが表示されること
- New PasswordとCheck Passwordが一致していない場合にエラーが表示されること
- パスワードが更新されたことを他のユーザーを使用して確認する

## 関連issue

- resolve https://github.com/ryo-manba/ft_transcendence/issues/164
- resolve https://github.com/ryo-manba/ft_transcendence/issues/120