### PR TITLE
チャットルームのユーザーをBANできるようにした

### DIFF
--- a/backend/prisma/migrations/20221213092321_add_chatroom_members_type/migration.sql
+++ b/backend/prisma/migrations/20221213092321_add_chatroom_members_type/migration.sql
@@ -1,0 +1,5 @@
+-- CreateEnum
+CREATE TYPE "ChatroomMembersStatus" AS ENUM ('NORMAL', 'BAN', 'MUTE');
+
+-- AlterTable
+ALTER TABLE "ChatroomMembers" ADD COLUMN     "status" "ChatroomMembersStatus" NOT NULL DEFAULT 'NORMAL';

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -69,15 +69,22 @@ enum ChatroomType {
 }
 
 model ChatroomMembers {
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @default(now()) @updatedAt
-  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
+  createdAt  DateTime              @default(now())
+  updatedAt  DateTime              @default(now()) @updatedAt
+  chatroom   Chatroom              @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   chatroomId Int
-  user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  user       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId     Int
+  status     ChatroomMembersStatus @default(NORMAL)
 
   @@id([chatroomId, userId])
   @@unique([chatroomId, userId])
+}
+
+enum ChatroomMembersStatus {
+  NORMAL
+  BAN
+  MUTE
 }
 
 model Message {
@@ -85,7 +92,7 @@ model Message {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now()) @updatedAt
   message    String
-  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade) // Roomが消されたらメッセージも削除される
+  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   chatroomId Int
   user       User     @relation(fields: [userId], references: [id])
   userId     Int
@@ -94,7 +101,7 @@ model Message {
 model ChatroomAdmin {
   createdAt  DateTime @default(now())
   updatedAt  DateTime @default(now()) @updatedAt
-  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade) // Roomが消されたらメッセージも削除される
+  chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   chatroomId Int
   user       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId     Int

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -18,4 +18,17 @@ export class ChatController {
   ): Promise<ChatUser[]> {
     return await this.chatService.findNotAdminUsers(roomId);
   }
+
+  /**
+   * @param roomId
+   * @return 以下の情報をオブジェクトの配列で返す
+   * - BANされていないユーザーのID
+   * - BANされていないユーザーの名前
+   */
+  @Get('non-banned')
+  async findNotBannedUsers(
+    @Query('roomId', ParseIntPipe) roomId: number,
+  ): Promise<ChatUser[]> {
+    return await this.chatService.findNotBannedUsers(roomId);
+  }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -99,15 +99,16 @@ export class ChatGateway {
   }
 
   /**
-   * チャットルームに対応したメッセージを取得して返す
-   * @param RoomID
+   * ソケットを引数で受けとったルームにjoinさせる
+   * @param roomID
+   * @return チャットルームに対応したメッセージを取得して返す
    */
-  @SubscribeMessage('chat:getMessage')
+  @SubscribeMessage('chat:changeCurrentRoom')
   async onGetMessage(
     @ConnectedSocket() client: Socket,
     @MessageBody() roomId: number,
   ): Promise<any> {
-    this.logger.log(`chat:getMessage received -> ${roomId}`);
+    this.logger.log(`chat:changeCurrentRoom received -> ${roomId}`);
 
     // 0番目には、socketのidが入っている
     if (client.rooms.size >= 2) {
@@ -120,8 +121,9 @@ export class ChatGateway {
     // 既存のメッセージを取得する
     // TODO: limitで上限をつける
     const messages = await this.chatService.findMessages({ id: roomId });
+
     // 既存のメッセージを送り返す
-    client.emit('chat:getMessage', messages);
+    return messages;
   }
 
   /**

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -5,6 +5,7 @@ import {
   WebSocketServer,
   ConnectedSocket,
 } from '@nestjs/websockets';
+import { Chatroom, ChatroomType } from '@prisma/client';
 import { Server, Socket } from 'socket.io';
 import { Logger } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
@@ -15,7 +16,7 @@ import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { CreateAdminDto } from './dto/create-admin.dto';
 import { updatePasswordDto } from './dto/update-password.dto';
-import { Chatroom, ChatroomType } from '@prisma/client';
+import { updateMemberStatusDto } from './dto/update-member-status.dto';
 
 @WebSocketGateway({
   cors: {
@@ -299,5 +300,20 @@ export class ChatGateway {
     );
 
     return await this.chatService.updatePassword(dto);
+  }
+
+  /**
+   * @param updateChatMemberStatusDto
+   * @return 以下の情報をオブジェクトの配列で返す
+   */
+  @SubscribeMessage('chat:banUser')
+  async banUser(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: updateMemberStatusDto,
+  ): Promise<boolean> {
+    this.logger.log(`chat:banUser received -> roomId: ${dto.chatroomId}`);
+    const res = await this.chatService.updateMemberStatus(dto);
+
+    return res ? true : false;
   }
 }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -281,20 +281,20 @@ export class ChatService {
    * @param roomId
    */
   async findNotBannedUsers(roomId: number): Promise<ChatUser[]> {
-    // ルームに所属しているユーザー一覧を取得する
-    const joinedUsersInfo = await this.prisma.chatroomMembers.findMany({
+    // ルームに所属している かつ statusがBAN以外のユーザーを取得する
+    const notBannedUsersInfo = await this.prisma.chatroomMembers.findMany({
       where: {
-        chatroomId: roomId,
+        AND: {
+          chatroomId: roomId,
+          status: {
+            not: ChatroomMembersStatus.BAN,
+          },
+        },
       },
       include: {
         user: true,
       },
     });
-
-    // statusがBANのユーザーを取り除く
-    const notBannedUsersInfo = joinedUsersInfo.filter(
-      (info) => info.status !== ChatroomMembersStatus.BAN,
-    );
 
     // idと名前の配列にする
     const notBannedUsers: ChatUser[] = notBannedUsersInfo.map((info) => {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -154,13 +154,27 @@ export class ChatService {
   }
 
   /**
+   * 入室しているユーザーの情報を返す
+   * @param userId
+   */
+  async findJoinedUserInfo(
+    chatroomMembersWhereUniqueInput: Prisma.ChatroomMembersWhereUniqueInput,
+  ): Promise<ChatroomMembers | null> {
+    // チャットルームメンバーからuserIdが含まれているものを取得する
+    const userInfo = await this.prisma.chatroomMembers.findUnique({
+      where: chatroomMembersWhereUniqueInput,
+    });
+
+    return userInfo;
+  }
+
+  /**
    * チャットルームに入室する
    * @param id
    * @return 入室したチャットルームを返す
    */
   async joinRoom(dto: JoinChatroomDto): Promise<Chatroom> {
     console.log('joinRoom: ', dto);
-    // TODO: ブロックされているユーザーは入れないようにする?
     // 入室するチャットルームを取得する
     const chatroom = await this.prisma.chatroom.findUnique({
       where: {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -5,6 +5,7 @@ import {
   Chatroom,
   ChatroomAdmin,
   ChatroomType,
+  ChatroomMembers,
   Message,
   Prisma,
   ChatroomMembersStatus,
@@ -15,6 +16,7 @@ import { CreateAdminDto } from './dto/create-admin.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import type { ChatUser } from './types/chat';
 import { updatePasswordDto } from './dto/update-password.dto';
+import { updateMemberStatusDto } from './dto/update-member-status.dto';
 
 // 2の12乗回の演算が必要という意味
 const saltRounds = 12;
@@ -345,6 +347,32 @@ export class ChatService {
       return true;
     } catch (err) {
       return false;
+    }
+  }
+
+  /**
+   * チャットルームに所属するユーザーのステータスを更新する
+   * @param updateMemberStatusDto
+   */
+  async updateMemberStatus(
+    dto: updateMemberStatusDto,
+  ): Promise<ChatroomMembers> {
+    try {
+      const res = await this.prisma.chatroomMembers.update({
+        data: {
+          status: dto.status,
+        },
+        where: {
+          chatroomId_userId: {
+            chatroomId: dto.chatroomId,
+            userId: dto.userId,
+          },
+        },
+      });
+
+      return res;
+    } catch (err) {
+      return undefined;
     }
   }
 }

--- a/backend/src/chat/dto/check-ban.dto.ts
+++ b/backend/src/chat/dto/check-ban.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class CheckBanDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+}

--- a/backend/src/chat/dto/update-member-status.dto.ts
+++ b/backend/src/chat/dto/update-member-status.dto.ts
@@ -1,0 +1,16 @@
+import { IsNotEmpty, IsNumber, IsEnum } from 'class-validator';
+import { ChatroomMembersStatus } from '@prisma/client';
+
+export class updateMemberStatusDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+
+  @IsEnum(ChatroomMembersStatus)
+  @IsNotEmpty()
+  status: ChatroomMembersStatus;
+}

--- a/frontend/api/chat/fetchNotBannedUsers.ts
+++ b/frontend/api/chat/fetchNotBannedUsers.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { ChatUser } from 'types/chat';
+
+type Props = {
+  roomId: number;
+};
+
+const endpoint = `${process.env.NEXT_PUBLIC_API_URL as string}/chat/non-banned`;
+
+export const fetchNotBannedUsers = async ({ roomId }: Props) => {
+  try {
+    const response = await axios.get<ChatUser[]>(endpoint, {
+      params: { roomId: roomId },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+
+    return [];
+  }
+};

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { memo, useState, useEffect, Dispatch, SetStateAction } from 'react';
 import {
   ListItem,
   IconButton,
@@ -10,7 +10,7 @@ import {
 import SettingsIcon from '@mui/icons-material/Settings';
 import CloseIcon from '@mui/icons-material/Close';
 import { Socket } from 'socket.io-client';
-import { Chatroom, ChatroomType, JoinChatroomInfo } from 'types/chat';
+import { Chatroom, Message, ChatroomType, JoinChatroomInfo } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 import { ChatroomSettingDialog } from 'components/chat/chatroom/ChatroomSettingDialog';
@@ -20,10 +20,16 @@ import { ChatroomMembersStatus } from '@prisma/client';
 type Props = {
   room: Chatroom;
   socket: Socket;
-  setCurrentRoomId: (id: number) => void;
+  setCurrentRoomId: Dispatch<SetStateAction<number>>;
+  setMessages: Dispatch<SetStateAction<Message[]>>;
 };
 
-export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
+export const ChatroomListItem = memo(function ChatroomListItem({
+  room,
+  socket,
+  setCurrentRoomId,
+  setMessages,
+}: Props) {
   const [open, setOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
   const [success, setSuccess] = useState('');
@@ -47,9 +53,13 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     return <Loading />;
   }
 
+  // ルームをクリックしたときの処理
   const getMessage = (id: number) => {
     console.log('getMessage:', id);
-    socket.emit('chat:getMessage', id);
+    // 入室に成功したら、既存のメッセージを受け取る
+    socket.emit('chat:changeCurrentRoom', id, (messages: Message[]) => {
+      setMessages(messages);
+    });
     setCurrentRoomId(id);
   };
 
@@ -228,4 +238,4 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
       )}
     </>
   );
-};
+});

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -25,7 +25,7 @@ type Props = {
 export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const [open, setOpen] = useState(false);
   const [isAdmin, setIsAdmin] = useState(false);
-  const [changeSuccess, setChangeSuccess] = useState(false);
+  const [success, setSuccess] = useState('');
   const { data: user } = useQueryUser();
 
   useEffect(() => {
@@ -64,7 +64,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const deleteRoom = () => {
     // 削除できるのはチャットルームオーナーだけ
     if (user.id !== room.ownerId) {
-      setError('Only the owner can delete chat rooms');
+      setError('Only the owner can delete chat rooms.');
     } else {
       const deleteRoomInfo = {
         id: room.id,
@@ -89,7 +89,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   const addAdmin = (userId: number) => {
     // Adminを設定できるのはチャットルームオーナーだけ
     if (user.id !== room.ownerId) {
-      setError('Only the owner can set admin');
+      setError('Only the owner can set admin.');
     } else {
       const setAdminInfo = {
         userId: userId,
@@ -99,7 +99,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
       // callbackを受け取ることで判断する
       socket.emit('chat:addAdmin', setAdminInfo, (res: boolean) => {
         if (!res) {
-          setError('Failed to add admin');
+          setError('Failed to add admin.');
         }
       });
     }
@@ -111,7 +111,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     checkPassword: string,
   ) => {
     if (newPassword !== checkPassword) {
-      setError('Check passwords did not match');
+      setError('Check passwords did not match.');
 
       return;
     }
@@ -122,9 +122,19 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
     };
     socket.emit('chat:updatePassword', changePasswordInfo, (res: boolean) => {
       if (res) {
-        setChangeSuccess(true);
+        setSuccess(`${room.name} password has been changed successfully.`);
       } else {
-        setError('Failed to change password');
+        setError('Failed to change password.');
+      }
+    });
+  };
+
+  const banUser = (userId: number) => {
+    socket.emit('chat:banUser', userId, (res: boolean) => {
+      if (res) {
+        setSuccess(`${room.name} user has been banned successfully.`);
+      } else {
+        setError('Failed to ban user.');
       }
     });
   };
@@ -140,7 +150,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
         </Collapse>
       </Box>
       <Box sx={{ width: '100%' }}>
-        <Collapse in={changeSuccess}>
+        <Collapse in={success !== ''}>
           <Alert
             severity="success"
             action={
@@ -149,7 +159,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
                 color="inherit"
                 size="small"
                 onClick={() => {
-                  setChangeSuccess(false);
+                  setSuccess('');
                 }}
               >
                 <CloseIcon fontSize="inherit" />
@@ -157,7 +167,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             }
             sx={{ mb: 2 }}
           >
-            {room.name} password changed.
+            {success}
           </Alert>
         </Collapse>
       </Box>
@@ -183,6 +193,7 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
             addFriend={addFriend}
             addAdmin={addAdmin}
             changePassword={changePassword}
+            banUser={banUser}
           />
           <ListItemText
             primary={room.name}

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -148,7 +148,7 @@ export const ChatroomListItem = memo(function ChatroomListItem({
     };
     socket.emit('chat:updatePassword', changePasswordInfo, (res: boolean) => {
       if (res) {
-        setSuccess(`${room.name} password has been changed successfully.`);
+        setSuccess('Password has been changed successfully.');
       } else {
         setError('Failed to change password.');
       }
@@ -165,7 +165,7 @@ export const ChatroomListItem = memo(function ChatroomListItem({
 
     socket.emit('chat:banUser', banUserInfo, (res: boolean) => {
       if (res) {
-        setSuccess(`${room.name} user has been banned successfully.`);
+        setSuccess('User has been banned successfully.');
       } else {
         setError('Failed to ban user.');
       }
@@ -200,7 +200,7 @@ export const ChatroomListItem = memo(function ChatroomListItem({
             }
             sx={{ mb: 2 }}
           >
-            {success}
+            {`${room.name}: ${success}`}
           </Alert>
         </Collapse>
       </Box>

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -15,6 +15,7 @@ import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 import { ChatroomSettingDialog } from 'components/chat/chatroom/ChatroomSettingDialog';
 import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
+import { ChatroomMembersStatus } from '@prisma/client';
 
 type Props = {
   room: Chatroom;
@@ -130,7 +131,14 @@ export const ChatroomListItem = ({ room, socket, setCurrentRoomId }: Props) => {
   };
 
   const banUser = (userId: number) => {
-    socket.emit('chat:banUser', userId, (res: boolean) => {
+    console.log('ban:', ChatroomMembersStatus.BAN);
+    const banUserInfo = {
+      chatroomId: room.id,
+      userId: userId,
+      status: ChatroomMembersStatus.BAN,
+    };
+
+    socket.emit('chat:banUser', banUserInfo, (res: boolean) => {
       if (res) {
         setSuccess(`${room.name} user has been banned successfully.`);
       } else {

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -150,11 +150,11 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
 
   useEffect(() => {
     if (user === undefined) return;
-    // ミュートする項目を選択時に取得する
+    // BANする項目を選択時に取得する
     if (selectedRoomSetting !== CHATROOM_SETTINGS.BAN_USER) return;
 
     const fetchCanBanUsers = async () => {
-      // チャットルーム入室している かつ すでにミュートされていないユーザーを取得する
+      // チャットルーム入室している かつ すでにBANされていないユーザーを取得する
       const notBannedUsers = await fetchNotBannedUsers({
         roomId: room.id,
       });

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -76,7 +76,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   const schema = z.object({
     oldPassword: z.string().refine(
       (value: string) =>
-        selectedRoomSetting === CHATROOM_SETTINGS.CHANGE_PASSWORD &&
+        selectedRoomSetting !== CHATROOM_SETTINGS.CHANGE_PASSWORD ||
         value.length >= 5,
       () => ({
         message: 'Passwords must be at least 5 characters',
@@ -84,7 +84,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     ),
     newPassword: z.string().refine(
       (value: string) =>
-        selectedRoomSetting === CHATROOM_SETTINGS.CHANGE_PASSWORD &&
+        selectedRoomSetting !== CHATROOM_SETTINGS.CHANGE_PASSWORD ||
         value.length >= 5,
       () => ({
         message: 'Passwords must be at least 5 characters',
@@ -92,7 +92,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     ),
     checkPassword: z.string().refine(
       (value: string) =>
-        selectedRoomSetting === CHATROOM_SETTINGS.CHANGE_PASSWORD &&
+        selectedRoomSetting !== CHATROOM_SETTINGS.CHANGE_PASSWORD ||
         value.length >= 5,
       () => ({
         message: 'Passwords must be at least 5 characters',
@@ -232,7 +232,8 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         console.log(selectedRoomSetting);
         break;
       case CHATROOM_SETTINGS.BAN_USER:
-        banUser(room.id);
+        console.log('BAN_USER');
+        banUser(Number(selectedUserId));
         break;
     }
     handleClose();

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -4,20 +4,20 @@ import { List } from '@mui/material';
 import { ChatroomListItem } from 'components/chat/chatroom/ChatroomListItem';
 import { ChatroomCreateButton } from 'components/chat/chatroom/ChatroomCreateButton';
 import { ChatroomJoinButton } from 'components/chat/chatroom/ChatroomJoinButton';
-import { Chatroom } from 'types/chat';
+import { Chatroom, Message } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 
 type Props = {
   socket: Socket;
   setCurrentRoomId: Dispatch<SetStateAction<number>>;
-  clearMessages: () => void;
+  setMessages: Dispatch<SetStateAction<Message[]>>;
 };
 
 export const ChatroomSidebar = memo(function ChatroomSidebar({
   socket,
   setCurrentRoomId,
-  clearMessages,
+  setMessages,
 }: Props) {
   const { data: user } = useQueryUser();
   const [rooms, setRooms] = useState<Chatroom[]>([]);
@@ -43,7 +43,7 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
     socket.on('chat:deleteRoom', (deletedRoom: Chatroom) => {
       console.log('chat:deleteRoom', deletedRoom);
       // 表示中のメッセージを削除する
-      clearMessages();
+      setMessages([]);
       setCurrentRoomId(0);
       // socketの退出処理をする
       socket.emit('chat:leaveRoom');
@@ -78,6 +78,7 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
               room={room}
               socket={socket}
               setCurrentRoomId={setCurrentRoomId}
+              setMessages={setMessages}
             />
           ))}
       </List>

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -39,11 +39,6 @@ const Chat = () => {
       setMessages((prev) => [...prev, data]);
     });
 
-    // 入室に成功したら、既存のメッセージを受け取る
-    socket.on('chat:getMessage', (data: Message[]) => {
-      setMessages(data);
-    });
-
     // メッセージが送信できたら、反映させる
     socket.on('chat:sendMessage', (data: Message) => {
       console.log('chat:sendMessage', data.message);
@@ -64,7 +59,6 @@ const Chat = () => {
 
     return () => {
       socket.off('chat:receiveMessage');
-      socket.off('chat:getMessage');
       socket.off('chat:sendMessage');
       socket.off('chat:deleteRoom');
     };
@@ -99,11 +93,6 @@ const Chat = () => {
     setText('');
   };
 
-  // 表示中のチャットルームが削除されたときに実行する
-  const clearMessages = () => {
-    setMessages([]);
-  };
-
   return (
     <>
       <Header title="Chatroom" />
@@ -124,7 +113,7 @@ const Chat = () => {
           <ChatroomSidebar
             socket={socket}
             setCurrentRoomId={setCurrentRoomId}
-            clearMessages={clearMessages}
+            setMessages={setMessages}
           />
         </Grid>
         <Grid

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -34,12 +34,13 @@ model ChatroomAdmin {
 }
 
 model ChatroomMembers {
-  createdAt  DateTime @default(now())
-  updatedAt  DateTime @default(now())
+  createdAt  DateTime              @default(now())
+  updatedAt  DateTime              @default(now())
   chatroomId Int
   userId     Int
-  Chatroom   Chatroom @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
-  User       User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+  status     ChatroomMembersStatus @default(NORMAL)
+  Chatroom   Chatroom              @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
+  User       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@id([chatroomId, userId])
   @@unique([chatroomId, userId])
@@ -108,4 +109,10 @@ enum UserStatus {
   ONLINE
   PLAYING
   OFFLINE
+}
+
+enum ChatroomMembersStatus {
+  NORMAL
+  BAN
+  MUTE
 }


### PR DESCRIPTION
## 概要
- BAN機能を追加した
- BANされたユーザーは、一定期間、発言したりチャットの内容を見ることができない
- 実装は以下のissueに書いてます
https://github.com/ryo-manba/ft_transcendence/issues/185

## 動作確認
- user1でroom1を作成する
- user2でroom1に入室する
- user1でuser2をBANする
- user2でroom1をクリックするとチャットルームのメッセージが表示されない(送信もできない)

## 次回やること
- 現状BANされたユーザーが復帰する手段がないです。
- 仕様には一定期間BANさせるとあるため、期間についてはMUTE機能と一緒に実装しようと思います。

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/177

## demo

https://user-images.githubusercontent.com/76232929/207889946-49024851-b5d8-4ab3-824c-869707b55206.mov


