### PR TITLE
Revert "Revert "チャットルームの設定周りをリファクタ""

### DIFF
--- a/backend/prisma/migrations/20221218151606_add_mute_or_ban_term/migration.sql
+++ b/backend/prisma/migrations/20221218151606_add_mute_or_ban_term/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "ChatroomMembers" ADD COLUMN     "endAt" TIMESTAMP(3),
+ADD COLUMN     "startAt" TIMESTAMP(3);

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -79,6 +79,8 @@ model ChatroomMembers {
   user       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
   userId     Int
   status     ChatroomMembersStatus @default(NORMAL)
+  startAt    DateTime? // BAN or MUTEの期間
+  endAt      DateTime?
 
   @@id([chatroomId, userId])
   @@unique([chatroomId, userId])

--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -16,7 +16,7 @@ export class ChatController {
   async findNotAdminUsers(
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<ChatUser[]> {
-    return await this.chatService.findNotAdminUsers(roomId);
+    return await this.chatService.findCanSetAdminUsers(roomId);
   }
 
   /**
@@ -30,5 +30,19 @@ export class ChatController {
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<ChatUser[]> {
     return await this.chatService.findNotBannedUsers(roomId);
+  }
+
+  /**
+   * @param roomId
+   * @return 以下を満たすユーザーのIDと名前の配列を返す
+   * - StatusがNormal
+   * - Adminではない
+   * - オーナーではない
+   */
+  @Get('normal-users')
+  async findChatroomNormalUsers(
+    @Query('roomId', ParseIntPipe) roomId: number,
+  ): Promise<ChatUser[]> {
+    return await this.chatService.findChatroomNormalUsers(roomId);
   }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -89,14 +89,31 @@ export class ChatGateway {
   async onMessage(
     @ConnectedSocket() client: Socket,
     @MessageBody() createMessageDto: CreateMessageDto,
-  ): Promise<any> {
+  ): Promise<boolean> {
     this.logger.log(
       `chat:sendMessage received -> ${createMessageDto.chatroomId}`,
     );
-    await this.chatService.addMessage(createMessageDto);
+
+    // BAN or MUTEされていないことを確認する
+    const userInfo = await this.chatService.findJoinedUserInfo({
+      chatroomId_userId: {
+        chatroomId: createMessageDto.chatroomId,
+        userId: createMessageDto.userId,
+      },
+    });
+    if (userInfo.status !== ChatroomMembersStatus.NORMAL) {
+      return false;
+    }
+
+    const res = await this.chatService.addMessage(createMessageDto);
+    if (res === undefined) {
+      return false;
+    }
     this.server
       .to(String(createMessageDto.chatroomId))
       .emit('chat:receiveMessage', createMessageDto);
+
+    return true;
   }
 
   /**
@@ -328,8 +345,8 @@ export class ChatGateway {
   }
 
   /**
-   * @param updateChatMemberStatusDto
-   * @return 以下の情報をオブジェクトの配列で返す
+   * ユーザーをBANする
+   * @param updateMemberStatusDto
    */
   @SubscribeMessage('chat:banUser')
   async banUser(
@@ -337,6 +354,21 @@ export class ChatGateway {
     @MessageBody() dto: updateMemberStatusDto,
   ): Promise<boolean> {
     this.logger.log(`chat:banUser received -> roomId: ${dto.chatroomId}`);
+    const res = await this.chatService.updateMemberStatus(dto);
+
+    return res ? true : false;
+  }
+
+  /**
+   * ユーザーをMUTEする
+   * @param updateChatMemberStatusDto
+   */
+  @SubscribeMessage('chat:muteUser')
+  async muteUser(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: updateMemberStatusDto,
+  ): Promise<boolean> {
+    this.logger.log(`chat:muteUser received -> roomId: ${dto.chatroomId}`);
     const res = await this.chatService.updateMemberStatus(dto);
 
     return res ? true : false;

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -264,15 +264,7 @@ export class ChatService {
    * @param roomId
    */
   async findCanSetAdminUsers(roomId: number): Promise<ChatUser[]> {
-    // ルームのadmin一覧を取得する
-    const adminUsers = await this.prisma.chatroomAdmin.findMany({
-      where: {
-        chatroomId: roomId,
-      },
-      select: {
-        userId: true,
-      },
-    });
+    const adminUsers = await this.findAdmins(roomId);
 
     // idの配列にする
     const adminUserIds = adminUsers.map((admin) => {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Logger } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 import { PrismaService } from '../prisma.service';
 import {
@@ -24,6 +24,7 @@ const saltRounds = 12;
 @Injectable()
 export class ChatService {
   constructor(private prisma: PrismaService) {}
+  private logger: Logger = new Logger('ChatService');
 
   async findOne(
     chatroomWhereUniqueInput: Prisma.ChatroomWhereUniqueInput,
@@ -94,15 +95,17 @@ export class ChatService {
   }
 
   async addMessage(createMessageDto: CreateMessageDto): Promise<Message> {
-    console.log(createMessageDto);
+    try {
+      const message = await this.prisma.message.create({
+        data: {
+          ...createMessageDto,
+        },
+      });
 
-    const Message = await this.prisma.message.create({
-      data: {
-        ...createMessageDto,
-      },
-    });
-
-    return Message;
+      return message;
+    } catch (err) {
+      return undefined;
+    }
   }
 
   /**
@@ -155,7 +158,9 @@ export class ChatService {
 
   /**
    * 入室しているユーザーの情報を返す
-   * @param userId
+   * - ユーザーがMUTE or BANされている場合は期間を確認する
+   * - 期間を越えている場合は、ステータスをNORMALに戻す
+   * @param ChatroomMembersWhereUniqueInput
    */
   async findJoinedUserInfo(
     chatroomMembersWhereUniqueInput: Prisma.ChatroomMembersWhereUniqueInput,
@@ -164,6 +169,27 @@ export class ChatService {
     const userInfo = await this.prisma.chatroomMembers.findUnique({
       where: chatroomMembersWhereUniqueInput,
     });
+
+    // NORMAL以外の場合は期間が過ぎていないかを確認する
+    if (userInfo.status !== ChatroomMembersStatus.NORMAL) {
+      const startAt = userInfo.startAt?.getTime();
+      const endAt = userInfo.endAt?.getTime();
+      const now = Date.now();
+
+      // 期間内ではなかった場合NORMALに更新する
+      if (!(startAt <= now && now <= endAt)) {
+        const dto: updateMemberStatusDto = {
+          userId: userInfo.userId,
+          chatroomId: userInfo.chatroomId,
+          status: ChatroomMembersStatus.NORMAL,
+        };
+        try {
+          return await this.updateMemberStatus(dto);
+        } catch (err) {
+          return undefined;
+        }
+      }
+    }
 
     return userInfo;
   }
@@ -234,24 +260,17 @@ export class ChatService {
   }
 
   /**
-   * 所属している かつ adminではないユーザ一覧を返す
+   * チャットルームに所属している かつ adminではない かつ BANもMUTEもされていないユーザ一覧を返す
    * @param roomId
    */
-  async findNotAdminUsers(roomId: number): Promise<ChatUser[]> {
-    // ルームに所属しているユーザー一覧を取得する
-    const joinedUsersInfo = await this.prisma.chatroomMembers.findMany({
-      where: {
-        chatroomId: roomId,
-      },
-      include: {
-        user: true,
-      },
-    });
-
+  async findCanSetAdminUsers(roomId: number): Promise<ChatUser[]> {
     // ルームのadmin一覧を取得する
     const adminUsers = await this.prisma.chatroomAdmin.findMany({
       where: {
         chatroomId: roomId,
+      },
+      select: {
+        userId: true,
       },
     });
 
@@ -260,24 +279,36 @@ export class ChatService {
       return admin.userId;
     });
 
-    // adminのユーザー除去する
-    const notAdminUsersInfo = joinedUsersInfo.filter(
-      (info) => !adminUserIds.includes(info.user.id),
-    );
-
-    // idと名前の配列にする
-    const notAdminUsers: ChatUser[] = notAdminUsersInfo.map((info) => {
-      return {
-        id: info.user.id,
-        name: info.user.name,
-      };
+    // adminではない かつ statusがNORMAL
+    const canSetAdminUsersInfo = await this.prisma.chatroomMembers.findMany({
+      where: {
+        AND: {
+          chatroomId: roomId,
+          NOT: {
+            userId: { in: adminUserIds },
+          },
+          status: ChatroomMembersStatus.NORMAL,
+        },
+      },
+      include: {
+        user: {
+          select: {
+            id: true,
+            name: true,
+          },
+        },
+      },
     });
 
-    return notAdminUsers;
+    const canSetAdminUsers: ChatUser[] = canSetAdminUsersInfo.map((info) => {
+      return info.user;
+    });
+
+    return canSetAdminUsers;
   }
 
   /**
-   * 所属している かつ BANされていないユーザ一覧を返す
+   * チャットルームに所属している かつ BANされていない かつ adminではないユーザ一覧を返す
    * @param roomId
    */
   async findNotBannedUsers(roomId: number): Promise<ChatUser[]> {
@@ -305,6 +336,53 @@ export class ChatService {
     });
 
     return notBannedUsers;
+  }
+
+  /**
+   * 下記を満たすユーザ一覧を返す
+   * - チャットルームに所属している
+   * - statusがNORMAL
+   * - adminではない
+   * - オーナーではない
+   * @param roomId
+   */
+  async findChatroomNormalUsers(roomId: number): Promise<ChatUser[]> {
+    // adminを取得する
+    const adminUsers = await this.findAdmins(roomId);
+    const adminUserIds = adminUsers.map((admin) => admin.userId);
+
+    // チャットルームのオーナーを取得する
+    const chatroom = await this.findOne({
+      id: roomId,
+    });
+    const ownerId = chatroom.ownerId;
+
+    const adminAndOwnerIds = [...adminUserIds, ownerId];
+
+    const normalUsersInfo = await this.prisma.chatroomMembers.findMany({
+      where: {
+        AND: {
+          chatroomId: roomId,
+          status: ChatroomMembersStatus.NORMAL,
+          NOT: {
+            userId: { in: adminAndOwnerIds },
+          },
+        },
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    // idと名前の配列にする
+    const normalUsers: ChatUser[] = normalUsersInfo.map((info) => {
+      return {
+        id: info.user.id,
+        name: info.user.name,
+      };
+    });
+
+    return normalUsers;
   }
 
   /**
@@ -371,10 +449,25 @@ export class ChatService {
   async updateMemberStatus(
     dto: updateMemberStatusDto,
   ): Promise<ChatroomMembers> {
+    const isNormal = dto.status === ChatroomMembersStatus.NORMAL;
+
+    const startAt = isNormal ? null : new Date();
+    let endAt = new Date();
+    if (!isNormal) {
+      // NOTE: とりあえず期間を1週間に設定している
+      endAt.setDate(startAt.getDate() + 7);
+    } else {
+      endAt = null;
+    }
+
+    this.logger.log(`startAt: ${startAt?.getDate()}`);
+    this.logger.log(`endAt: ${endAt?.getDate()}`);
     try {
       const res = await this.prisma.chatroomMembers.update({
         data: {
           status: dto.status,
+          startAt: startAt,
+          endAt: endAt,
         },
         where: {
           chatroomId_userId: {

--- a/frontend/api/chat/fetchCanSetAdminUsers.ts
+++ b/frontend/api/chat/fetchCanSetAdminUsers.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+import { ChatUser } from 'types/chat';
+
+type Props = {
+  roomId: number;
+};
+
+const endpoint = `${process.env.NEXT_PUBLIC_API_URL as string}/chat/non-admin`;
+
+export const fetchCanSetAdminUsers = async ({ roomId }: Props) => {
+  try {
+    const response = await axios.get<ChatUser[]>(endpoint, {
+      params: { roomId: roomId },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+
+    return [];
+  }
+};

--- a/frontend/api/chat/fetchChatroomNormalUsers.ts
+++ b/frontend/api/chat/fetchChatroomNormalUsers.ts
@@ -5,9 +5,11 @@ type Props = {
   roomId: number;
 };
 
-const endpoint = `${process.env.NEXT_PUBLIC_API_URL as string}/chat/non-admin`;
+const endpoint = `${
+  process.env.NEXT_PUBLIC_API_URL as string
+}/chat/normal-users`;
 
-export const fetchNotAdminUsers = async ({ roomId }: Props) => {
+export const fetchChatroomNormalUsers = async ({ roomId }: Props) => {
   try {
     const response = await axios.get<ChatUser[]>(endpoint, {
       params: { roomId: roomId },

--- a/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
@@ -1,5 +1,8 @@
 import { useState, memo, useCallback } from 'react';
 import { Socket } from 'socket.io-client';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import * as z from 'zod';
 import {
   Button,
   TextField,
@@ -8,22 +11,16 @@ import {
   DialogContent,
   DialogTitle,
   InputLabel,
-  IconButton,
-  InputAdornment,
   Select,
   SelectChangeEvent,
   MenuItem,
   FormControl,
 } from '@mui/material';
-import Visibility from '@mui/icons-material/Visibility';
-import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
 import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded';
 import { CreateChatroomInfo, ChatroomType, CHATROOM_TYPE } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
-import { useForm, SubmitHandler, Controller } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import * as z from 'zod';
+import { ChatPasswordForm } from 'components/chat/utils/ChatPasswordForm';
 
 type Props = {
   socket: Socket;
@@ -39,7 +36,6 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
 }: Props) {
   const [open, setOpen] = useState(false);
   const [roomType, setRoomType] = useState<ChatroomType>(CHATROOM_TYPE.PUBLIC);
-  const [showPassword, setShowPassword] = useState(false);
 
   const { data: user } = useQueryUser();
   if (user === undefined) {
@@ -151,49 +147,12 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
         </DialogContent>
         {roomType === CHATROOM_TYPE.PROTECTED && (
           <DialogContent>
-            <Controller
-              name="password"
+            <ChatPasswordForm
               control={control}
-              render={({ field }) => (
-                <TextField
-                  autoFocus
-                  margin="dense"
-                  label="Password"
-                  type={showPassword ? 'text' : 'password'}
-                  error={errors.password ? true : false}
-                  helperText={
-                    errors.password
-                      ? errors.password?.message
-                      : 'Must be min 5 characters'
-                  }
-                  InputProps={{
-                    endAdornment: (
-                      <InputAdornment position="end">
-                        <IconButton
-                          aria-label="toggle password visibility"
-                          onClick={() => {
-                            setShowPassword(!showPassword);
-                          }}
-                          onMouseDown={(event) => {
-                            event.preventDefault();
-                          }}
-                          edge="end"
-                        >
-                          {showPassword ? (
-                            <VisibilityOffIcon />
-                          ) : (
-                            <Visibility />
-                          )}
-                        </IconButton>
-                      </InputAdornment>
-                    ),
-                  }}
-                  fullWidth
-                  variant="standard"
-                  // eslint-disable-next-line react/jsx-props-no-spreading
-                  {...field}
-                />
-              )}
+              inputName="password"
+              labelName="Password"
+              error={errors.password}
+              helperText="Must be min 5 characters"
             />
           </DialogContent>
         )}
@@ -220,6 +179,7 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
           <Button
             onClick={handleSubmit(onSubmit) as VoidFunction}
             variant="contained"
+            autoFocus
           >
             Create
           </Button>

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -156,7 +156,6 @@ export const ChatroomListItem = memo(function ChatroomListItem({
   };
 
   const banUser = (userId: number) => {
-    console.log('ban:', ChatroomMembersStatus.BAN);
     const banUserInfo = {
       chatroomId: room.id,
       userId: userId,
@@ -168,6 +167,22 @@ export const ChatroomListItem = memo(function ChatroomListItem({
         setSuccess('User has been banned successfully.');
       } else {
         setError('Failed to ban user.');
+      }
+    });
+  };
+
+  const muteUser = (userId: number) => {
+    const muteUserInfo = {
+      chatroomId: room.id,
+      userId: userId,
+      status: ChatroomMembersStatus.MUTE,
+    };
+
+    socket.emit('chat:muteUser', muteUserInfo, (res: boolean) => {
+      if (res) {
+        setSuccess('User has been muted successfully.');
+      } else {
+        setError('Failed to mute user.');
       }
     });
   };
@@ -227,6 +242,7 @@ export const ChatroomListItem = memo(function ChatroomListItem({
             addAdmin={addAdmin}
             changePassword={changePassword}
             banUser={banUser}
+            muteUser={muteUser}
           />
           <ListItemText
             primary={room.name}

--- a/frontend/components/chat/chatroom/ChatroomSettingDetailDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDetailDialog.tsx
@@ -1,0 +1,60 @@
+import { memo } from 'react';
+import {
+  DialogContent,
+  InputLabel,
+  Select,
+  SelectChangeEvent,
+  MenuItem,
+  FormControl,
+} from '@mui/material';
+import { ChatUser } from 'types/chat';
+
+type Props = {
+  users: ChatUser[];
+  labelTitle: string;
+  selectedValue: string;
+  onChange: (event: SelectChangeEvent) => void;
+};
+
+export const ChatroomSettingDetailDialog = memo(
+  function ChatroomSettingDetailDialog({
+    users,
+    labelTitle,
+    selectedValue,
+    onChange,
+  }: Props) {
+    return (
+      <>
+        {users.length === 0 ? (
+          <div
+            className="mb-4 flex justify-center rounded-lg bg-red-100 p-4 text-sm text-red-700 dark:bg-red-200 dark:text-red-800"
+            role="alert"
+          >
+            <span className="font-medium">No users are available.</span>
+          </div>
+        ) : (
+          <DialogContent>
+            <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
+              <InputLabel id="room-setting-select-label">
+                {labelTitle}
+              </InputLabel>
+              <Select
+                labelId="room-setting-select-label"
+                id="room-setting"
+                value={selectedValue}
+                label="setting"
+                onChange={onChange}
+              >
+                {users.map((user) => (
+                  <MenuItem value={String(user.id)} key={user.id}>
+                    {user.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </DialogContent>
+        )}
+      </>
+    );
+  },
+);

--- a/frontend/components/chat/utils/ChatPasswordForm.tsx
+++ b/frontend/components/chat/utils/ChatPasswordForm.tsx
@@ -1,0 +1,65 @@
+import { memo, useState } from 'react';
+import { IconButton, InputAdornment, TextField } from '@mui/material';
+import Visibility from '@mui/icons-material/Visibility';
+import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
+import { Controller, FieldError, Control } from 'react-hook-form';
+
+type Props = {
+  // controlの型は各入力項目の個数によって異なるためanyにしている
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  control: Control<any>;
+  inputName: string;
+  labelName: string;
+  error: FieldError | undefined;
+  helperText: string;
+};
+
+export const ChatPasswordForm = memo(function ChatPasswordForm({
+  control,
+  inputName,
+  labelName,
+  error,
+  helperText,
+}: Props) {
+  const [showPassword, setShowPassword] = useState(false);
+
+  return (
+    <>
+      <Controller
+        name={inputName}
+        control={control}
+        render={({ field }) => (
+          <TextField
+            margin="dense"
+            label={labelName}
+            type={showPassword ? 'text' : 'password'}
+            error={error ? true : false}
+            helperText={error ? error.message : helperText}
+            InputProps={{
+              endAdornment: (
+                <InputAdornment position="end">
+                  <IconButton
+                    aria-label="toggle password visibility"
+                    onClick={() => {
+                      setShowPassword(!showPassword);
+                    }}
+                    onMouseDown={(event) => {
+                      event.preventDefault();
+                    }}
+                    edge="end"
+                  >
+                    {showPassword ? <VisibilityOffIcon /> : <Visibility />}
+                  </IconButton>
+                </InputAdornment>
+              ),
+            }}
+            fullWidth
+            variant="standard"
+            // eslint-disable-next-line react/jsx-props-no-spreading
+            {...field}
+          />
+        )}
+      />
+    </>
+  );
+});

--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -39,6 +39,8 @@ model ChatroomMembers {
   chatroomId Int
   userId     Int
   status     ChatroomMembersStatus @default(NORMAL)
+  endAt      DateTime?
+  startAt    DateTime?
   Chatroom   Chatroom              @relation(fields: [chatroomId], references: [id], onDelete: Cascade)
   User       User                  @relation(fields: [userId], references: [id], onDelete: Cascade)
 


### PR DESCRIPTION
- Reverts ryo-manba/ft_transcendence#198
(誤ってマージしてしまった兼ね合いでRevertのRevertになっています)

## 概要

- チャットルームの設定項目をまとめた
- パスワードの入力をまとめた
  - それに伴い、チャットルーム作成時のパスワード入力も置き換えている
- 機能に変更は加えていません

## その他
- ~以下がマージされてからレビューお願いします~
  - ~https://github.com/ryo-manba/ft_transcendence/pull/193~

- 原因がよくわかってないですが、以下のコミットが消えてしまったため以下の内容も含んでいます...。
  - https://github.com/ryo-manba/ft_transcendence/pull/193


## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/194