### PR TITLE
[WIP]入室しているルーム一覧の取得をaxiosで行うようにした

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -1,6 +1,7 @@
 import { Query, Controller, Get, ParseIntPipe } from '@nestjs/common';
 import { ChatService } from './chat.service';
 import type { ChatUser } from './types/chat';
+import type { Chatroom } from '@prisma/client';
 
 @Controller('chat')
 export class ChatController {
@@ -30,5 +31,16 @@ export class ChatController {
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<ChatUser[]> {
     return await this.chatService.findNotBannedUsers(roomId);
+  }
+
+  /**
+   * @param userId
+   * @return 入室しているチャットルーム一覧を返す
+   */
+  @Get('joined-rooms')
+  async findJoinedRooms(
+    @Query('userId', ParseIntPipe) userId: number,
+  ): Promise<Chatroom[]> {
+    return await this.chatService.findJoinedRooms(userId);
   }
 }

--- a/frontend/api/chat/fetchJoindRooms.ts
+++ b/frontend/api/chat/fetchJoindRooms.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import type { Chatroom } from 'types/chat';
+
+type Props = {
+  userId: number;
+};
+
+const endpoint = `${
+  process.env.NEXT_PUBLIC_API_URL as string
+}/chat/joined-rooms`;
+
+export const fetchJoinedRooms = async ({ userId }: Props) => {
+  try {
+    const response = await axios.get<Chatroom[]>(endpoint, {
+      params: { userId: userId },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+
+    return [];
+  }
+};

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -7,6 +7,7 @@ import { ChatroomJoinButton } from 'components/chat/chatroom/ChatroomJoinButton'
 import { Chatroom, Message } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
+import { fetchJoinedRooms } from 'api/chat/fetchJoindRooms';
 
 type Props = {
   socket: Socket;
@@ -51,15 +52,22 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       socket.emit('chat:getJoinedRooms', user.id);
     });
 
-    // setupが終わったら
-    // 入室中のチャットルーム一覧を取得する
-    socket.emit('chat:getJoinedRooms', user.id);
-
     return () => {
       socket.off('chat:getJoinedRooms');
       socket.off('chat:createRoom');
       socket.off('chat:updateSideBarRooms');
     };
+  }, []);
+
+  useEffect(() => {
+    if (user == undefined) return;
+    const fetchRooms = async () => {
+      const res = await fetchJoinedRooms({ userId: user.id });
+
+      setRooms(res);
+    };
+
+    void fetchRooms();
   }, []);
 
   if (user === undefined) {


### PR DESCRIPTION
## 概要
- チャットルームをリロードすると、たまに入室しているルーム一覧が取得できない場合があった
  - それに対し、フレンド一覧は必ず取得できている
- 原因はsocketの再接続のタイミングによるものだと判断した
- そこで、入室しているルーム一覧もフレンド同様axiosを使用するようにした

## 確認手順
- リロードしても入室しているルーム一覧が確実に取得できること

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/201