### PR TITLE
試合中にブラウザバックしてもゲームが中断されないバグの修正

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -442,7 +442,7 @@ export class GameGateway {
     socket.emit('joinGameRoom', room.gameState, gameSetting);
   }
 
-  @SubscribeMessage('cancel')
+  @SubscribeMessage('cancelOngoingBattle')
   cancelGame(@ConnectedSocket() socket: Socket) {
     const room = this.gameRooms.find(
       (r) =>
@@ -451,7 +451,7 @@ export class GameGateway {
     if (!room) {
       socket.emit('error');
     } else {
-      this.server.to(room.roomName).emit('canceled');
+      this.server.to(room.roomName).emit('cancelOngoingBattle');
       this.gameRooms = this.gameRooms.filter(
         (room) =>
           room.player1.socket.id !== socket.id &&

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -442,7 +442,7 @@ export class GameGateway {
     socket.emit('joinGameRoom', room.gameState, gameSetting);
   }
 
-  @SubscribeMessage('timeUp')
+  @SubscribeMessage('cancel')
   cancelGame(@ConnectedSocket() socket: Socket) {
     const room = this.gameRooms.find(
       (r) =>
@@ -451,7 +451,7 @@ export class GameGateway {
     if (!room) {
       socket.emit('error');
     } else {
-      this.server.to(room.roomName).emit('timedUp');
+      this.server.to(room.roomName).emit('canceled');
       this.gameRooms = this.gameRooms.filter(
         (room) =>
           room.player1.socket.id !== socket.id &&

--- a/frontend/components/game/battle/Result.tsx
+++ b/frontend/components/game/battle/Result.tsx
@@ -33,10 +33,10 @@ export const Result = ({ finishedGameInfo }: Props) => {
           </Typography>
         </Grid>
       )}
-      {playState === PlayState.stateTimedUp && (
+      {playState === PlayState.stateCanceled && (
         <Grid item sx={{ mt: 3 }}>
           <Typography align="center" gutterBottom variant="h4" component="h4">
-            Time is up. Please retry a new game.
+            The game was canceled. Please retry a new game.
           </Typography>
         </Grid>
       )}

--- a/frontend/components/game/battle/Setting.tsx
+++ b/frontend/components/game/battle/Setting.tsx
@@ -49,14 +49,14 @@ export const Setting = () => {
       updatePlayState(PlayState.stateNothing);
     });
 
-    socket.on('canceled', () => {
+    socket.on('cancelOngoingBattle', () => {
       updatePlayState(PlayState.stateCanceled);
     });
 
     return () => {
       socket.off('playStarted');
       socket.off('error');
-      socket.off('canceled');
+      socket.off('cancelOngoingBattle');
     };
   }, [socket]);
 
@@ -66,7 +66,7 @@ export const Setting = () => {
         updateCountDown(countDown - 1);
       }, timeoutIntervalInMilSec);
     } else if (countDown === 0) {
-      socket.emit('cancel');
+      socket.emit('cancelOngoingBattle');
       updatePlayState(PlayState.stateCanceled);
     }
   }, [countDown, socket]);

--- a/frontend/components/game/battle/Setting.tsx
+++ b/frontend/components/game/battle/Setting.tsx
@@ -49,14 +49,14 @@ export const Setting = () => {
       updatePlayState(PlayState.stateNothing);
     });
 
-    socket.on('timedUp', () => {
-      updatePlayState(PlayState.stateTimedUp);
+    socket.on('canceled', () => {
+      updatePlayState(PlayState.stateCanceled);
     });
 
     return () => {
       socket.off('playStarted');
       socket.off('error');
-      socket.off('timedUp');
+      socket.off('canceled');
     };
   }, [socket]);
 
@@ -66,8 +66,8 @@ export const Setting = () => {
         updateCountDown(countDown - 1);
       }, timeoutIntervalInMilSec);
     } else if (countDown === 0) {
-      socket.emit('timeUp');
-      updatePlayState(PlayState.stateTimedUp);
+      socket.emit('cancel');
+      updatePlayState(PlayState.stateCanceled);
     }
   }, [countDown, socket]);
 

--- a/frontend/pages/game/battle/index.tsx
+++ b/frontend/pages/game/battle/index.tsx
@@ -28,7 +28,7 @@ const Battle: NextPage = () => {
         <Play updateFinishedGameInfo={setFinishedGameInfo} />
       )}
       {(playState === PlayState.stateFinished ||
-        playState === PlayState.stateTimedUp ||
+        playState === PlayState.stateCanceled ||
         playState === PlayState.stateNothing) && (
         <Result finishedGameInfo={finishedGameInfo} />
       )}

--- a/frontend/store/game/PlayState.tsx
+++ b/frontend/store/game/PlayState.tsx
@@ -7,7 +7,7 @@ export const PlayState = {
   stateStandingBy: 3,
   statePlaying: 4,
   stateFinished: 5,
-  stateTimedUp: 6,
+  stateCanceled: 6,
 } as const;
 
 export type PlayState = typeof PlayState[keyof typeof PlayState];


### PR DESCRIPTION
## 動作概要

https://user-images.githubusercontent.com/15176241/209438757-37758fe8-5d88-490c-aa3c-322356d3f8a0.mov

## 備考

負けそうなプレーヤーがブラウザバックすると戦略的試合キャンセルができてしまうという問題はありますが、まぁ目をつむってもいいかなぁと思っています。

## 関連イシュー

- resolve #207 