### PR TITLE
Resultページの表示不具合の修正

### DIFF
--- a/frontend/components/game/battle/GameHeader.tsx
+++ b/frontend/components/game/battle/GameHeader.tsx
@@ -1,4 +1,4 @@
-import { Grid } from '@mui/material';
+import { Grid, Typography } from '@mui/material';
 
 type GameHeaderProps = {
   maxWidth: number;
@@ -9,7 +9,7 @@ type GameHeaderProps = {
 
 export const GameHeader = (props: GameHeaderProps) => {
   return (
-    <Grid container maxWidth={props.maxWidth}>
+    <Grid container maxWidth={props.maxWidth} wrap="nowrap" sx={{ pt: 2 }}>
       <Grid
         container
         item
@@ -17,8 +17,11 @@ export const GameHeader = (props: GameHeaderProps) => {
         direction="row"
         alignItems="center"
         justifyContent="center"
+        zeroMinWidth
       >
-        <h2>{props.left}</h2>
+        <Typography variant="h5" noWrap align="center">
+          {props.left}
+        </Typography>
       </Grid>
       <Grid
         container
@@ -28,7 +31,9 @@ export const GameHeader = (props: GameHeaderProps) => {
         alignItems="center"
         justifyContent="center"
       >
-        <h2>{props.center}</h2>
+        <Typography variant="h5" noWrap align="center">
+          {props.center}
+        </Typography>
       </Grid>
       <Grid
         container
@@ -37,8 +42,11 @@ export const GameHeader = (props: GameHeaderProps) => {
         direction="row"
         alignItems="center"
         justifyContent="center"
+        zeroMinWidth
       >
-        <h2>{props.right}</h2>
+        <Typography variant="h5" noWrap align="center">
+          {props.right}
+        </Typography>
       </Grid>
     </Grid>
   );

--- a/frontend/components/game/battle/Result.tsx
+++ b/frontend/components/game/battle/Result.tsx
@@ -47,7 +47,7 @@ export const Result = ({ finishedGameInfo }: Props) => {
               Result
             </Typography>
           </Grid>
-          <Grid container>
+          <Grid container spacing={3}>
             <Grid item xs={6}>
               <Typography
                 align="center"
@@ -55,7 +55,7 @@ export const Result = ({ finishedGameInfo }: Props) => {
                 variant="h4"
                 component="h4"
               >
-                Winner
+                Win
               </Typography>
             </Grid>
             <Grid item xs={6}>
@@ -65,33 +65,35 @@ export const Result = ({ finishedGameInfo }: Props) => {
                 variant="h4"
                 component="h4"
               >
-                Loser
+                Lose
               </Typography>
             </Grid>
           </Grid>
-          <Grid container>
-            <Grid item xs={6}>
+          <Grid container spacing={3} wrap="nowrap">
+            <Grid item xs={6} zeroMinWidth>
               <Typography
                 align="center"
                 gutterBottom
                 variant="h5"
                 component="h5"
+                noWrap
               >
                 {finishedGameInfo.winnerName}
               </Typography>
             </Grid>
-            <Grid item xs={6}>
+            <Grid item xs={6} zeroMinWidth>
               <Typography
                 align="center"
                 gutterBottom
                 variant="h5"
                 component="h5"
+                noWrap
               >
                 {finishedGameInfo.loserName}
               </Typography>
             </Grid>
           </Grid>
-          <Grid container>
+          <Grid container spacing={3}>
             <Grid item xs={6}>
               <Typography
                 align="center"


### PR DESCRIPTION
## 概要

- #217 の修正
- ついでに試合中に長いユーザー名が適切に表示されるように修正

![image](https://user-images.githubusercontent.com/15176241/209478711-91b26c06-cc9e-4200-a3a8-c12708330dcd.png)
## 関連イシュー

- resolve #217 