### PR TITLE
ユーザー名表示のバグ修正

### DIFF
--- a/frontend/components/game/home/Profile.tsx
+++ b/frontend/components/game/home/Profile.tsx
@@ -73,15 +73,16 @@ export const Profile = () => {
           justifyContent="center"
           alignItems="center"
           spacing={1}
+          wrap="nowrap"
         >
           <Grid item>
             <Avatar
               src={avatarImageUrl} // Avatar can show a default avatar image when the provided path is invalid
-              sx={{ width: 100, height: 100 }}
+              sx={{ width: 90, height: 90 }}
             />
           </Grid>
-          <Grid item>
-            <Typography gutterBottom variant="h5" component="div">
+          <Grid item sx={{ width: '75%' }}>
+            <Typography noWrap gutterBottom variant="h5" component="div">
               {user.name}
             </Typography>
           </Grid>

--- a/frontend/pages/dashboard/index.tsx
+++ b/frontend/pages/dashboard/index.tsx
@@ -16,7 +16,11 @@ const Dashboard: NextPage = () => {
   return (
     <Layout title="Dashboard">
       <Header title="ft_transcendence" />
-      <Typography variant="h3" gutterBottom sx={{ margin: '50px' }}>
+      <Typography
+        variant="h3"
+        gutterBottom
+        sx={{ margin: '50px', wordBreak: 'break-word' }}
+      >
         HELLO {user.name}
       </Typography>
       <Stack

--- a/frontend/pages/profile/index.tsx
+++ b/frontend/pages/profile/index.tsx
@@ -102,7 +102,13 @@ const Profile: NextPage = () => {
           />
         </Grid>
         <Grid item>
-          <Typography gutterBottom variant="h1" component="div">
+          <Typography
+            gutterBottom
+            variant="h1"
+            component="div"
+            align="center"
+            sx={{ wordBreak: 'break-word' }}
+          >
             {userName}
           </Typography>
         </Grid>


### PR DESCRIPTION
## 概要

#218 の修正

## スクリーンショット

- /game/homeのプロフィールに表示される名前は幅が狭い場合は省略表示
![image](https://user-images.githubusercontent.com/15176241/209507042-b6c3b228-66b0-4dec-976f-a7f8df3849b1.png)

- /profileに表示される名前はWrapして全て表示
![image](https://user-images.githubusercontent.com/15176241/209507101-ccc57e3d-a0b6-46d1-a98c-53eff80c2747.png)

- ついでに/dashboardに表示されるユーザー名も修正（/profileと同じ形式）
![image](https://user-images.githubusercontent.com/15176241/209507155-96aedbfb-3c52-433c-9b2a-028b25868fe8.png)

## 関連イシュー

- resolve #218