### PR TITLE
チャットルームを退出する機能を実装した

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -45,4 +45,15 @@ export class ChatController {
   ): Promise<ChatUser[]> {
     return await this.chatService.findChatroomNormalUsers(roomId);
   }
+
+  /**
+   * @param roomId
+   * @return chatroomに入室しているStatusがNormalなユーザーのIDと名前の配列を返す
+   */
+  @Get('active-users')
+  async findActiveUsers(
+    @Query('roomId', ParseIntPipe) roomId: number,
+  ): Promise<ChatUser[]> {
+    return await this.chatService.findChatroomActiveUsers(roomId);
+  }
 }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -213,7 +213,7 @@ export class ChatGateway {
     this.logger.log(`chat:leaveRoom received userId -> ${dto.userId}`);
 
     const deletedMember = await this.chatService.removeChatroomMember(dto);
-    if (deletedMember === undefined) {
+    if (!deletedMember) {
       return false;
     }
     await this.leaveSocket(client, dto.chatroomId);
@@ -224,7 +224,6 @@ export class ChatGateway {
         chatroomId: dto.chatroomId,
       },
     });
-    console.log('member:', member);
     if (!member) {
       const deleteChatroomDto: DeleteChatroomDto = {
         id: dto.chatroomId,

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -219,9 +219,13 @@ export class ChatGateway {
     await this.leaveSocket(client, dto.chatroomId);
 
     // チャットルームを抜けたことで入室者がいなくなる場合は削除する
+    // BAN or MUTEのユーザーは無視する
     const member = await this.prisma.chatroomMembers.findFirst({
       where: {
-        chatroomId: dto.chatroomId,
+        AND: {
+          chatroomId: dto.chatroomId,
+          status: ChatroomMembersStatus.NORMAL,
+        },
       },
     });
     if (!member) {

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -153,7 +153,7 @@ export class ChatService {
   async removeChatroomMember(
     dto: DeleteChatroomMemberDto,
   ): Promise<ChatroomMembers> {
-    this.logger.log('leaveRoom', dto);
+    this.logger.log('removeChatroomMember', dto);
 
     try {
       const deletedMember = await this.prisma.chatroomMembers.delete({
@@ -166,7 +166,7 @@ export class ChatService {
 
       return deletedMember;
     } catch (error) {
-      this.logger.log('leaveRoom', error);
+      this.logger.log('removeChatroomMember', error);
 
       return undefined;
     }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -19,6 +19,7 @@ import { updatePasswordDto } from './dto/update-password.dto';
 import { updateMemberStatusDto } from './dto/update-member-status.dto';
 import { createDirectMessageDto } from './dto/create-direct-message.dto';
 import { DeleteChatroomDto } from './dto/delete-chatroom.dto';
+import { DeleteChatroomMemberDto } from './dto/delete-chatroom-member.dto';
 
 // 2の12乗回の演算が必要という意味
 const saltRounds = 12;
@@ -142,6 +143,31 @@ export class ChatService {
 
       return message;
     } catch (err) {
+      return undefined;
+    }
+  }
+
+  /**
+   * chatroomのメンバーを削除する
+   */
+  async removeChatroomMember(
+    dto: DeleteChatroomMemberDto,
+  ): Promise<ChatroomMembers> {
+    this.logger.log('leaveRoom', dto);
+
+    try {
+      const deletedMember = await this.prisma.chatroomMembers.delete({
+        where: {
+          chatroomId_userId: {
+            ...dto,
+          },
+        },
+      });
+
+      return deletedMember;
+    } catch (error) {
+      this.logger.log('leaveRoom', error);
+
       return undefined;
     }
   }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -443,6 +443,33 @@ export class ChatService {
   }
 
   /**
+   * statusがNORMALなユーザ一覧を返す
+   * @param roomId
+   */
+  async findChatroomActiveUsers(roomId: number): Promise<ChatUser[]> {
+    const activeUsersInfo = await this.prisma.chatroomMembers.findMany({
+      where: {
+        AND: {
+          chatroomId: roomId,
+          status: ChatroomMembersStatus.NORMAL,
+        },
+      },
+      include: {
+        user: true,
+      },
+    });
+
+    const activeUsers: ChatUser[] = activeUsersInfo.map((info) => {
+      return {
+        id: info.user.id,
+        name: info.user.name,
+      };
+    });
+
+    return activeUsers;
+  }
+
+  /**
    * チャットルームのadminを作成する
    * @param CreateAdminDto
    */

--- a/backend/src/chat/dto/delete-chatroom-member.dto.ts
+++ b/backend/src/chat/dto/delete-chatroom-member.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class DeleteChatroomMemberDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+}

--- a/backend/src/chat/dto/update-chatroom-owner.dto.ts
+++ b/backend/src/chat/dto/update-chatroom-owner.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class UpdateChatroomOwnerDto {
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  ownerId: number;
+}

--- a/frontend/api/chat/fetchActiveUsers.ts
+++ b/frontend/api/chat/fetchActiveUsers.ts
@@ -1,0 +1,24 @@
+import axios from 'axios';
+import { ChatUser } from 'types/chat';
+
+type Props = {
+  roomId: number;
+};
+
+const endpoint = `${
+  process.env.NEXT_PUBLIC_API_URL as string
+}/chat/active-users`;
+
+export const fetchActiveUsers = async ({ roomId }: Props) => {
+  try {
+    const response = await axios.get<ChatUser[]>(endpoint, {
+      params: { roomId: roomId },
+    });
+
+    return response.data;
+  } catch (error) {
+    console.log(error);
+
+    return [];
+  }
+};

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -220,8 +220,6 @@ export const ChatroomListItem = memo(function ChatroomListItem({
         setCurrentRoomId(0);
         // 所属しているチャットルーム一覧を取得する
         socket.emit('chat:getJoinedRooms', user.id);
-
-        setSuccess('You have left the chat room.');
       } else {
         setError('Failed to leave room.');
       }

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -193,7 +193,22 @@ export const ChatroomListItem = memo(function ChatroomListItem({
     });
   };
 
-  const leaveRoom = () => {
+  const leaveRoom = (nextOwnerId: number | undefined) => {
+    // オーナーが退出する場合は別のユーザーを次のオーナーにする
+    if (user.id === room.ownerId && nextOwnerId) {
+      const changeOwnerInfo = {
+        chatroomId: room.id,
+        ownerId: nextOwnerId,
+      };
+      socket.emit('chat:changeRoomOwner', changeOwnerInfo, (res: boolean) => {
+        if (!res) {
+          setError('Failed to change room owner.');
+
+          return;
+        }
+      });
+    }
+
     const leaveRoomInfo = {
       chatroomId: room.id,
       userId: user.id,

--- a/frontend/components/chat/chatroom/ChatroomSettingDetailDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDetailDialog.tsx
@@ -14,6 +14,7 @@ type Props = {
   labelTitle: string;
   selectedValue: string;
   onChange: (event: SelectChangeEvent) => void;
+  message?: string;
 };
 
 export const ChatroomSettingDetailDialog = memo(
@@ -22,6 +23,7 @@ export const ChatroomSettingDetailDialog = memo(
     labelTitle,
     selectedValue,
     onChange,
+    message = 'No users are available.',
   }: Props) {
     return (
       <>
@@ -30,7 +32,7 @@ export const ChatroomSettingDetailDialog = memo(
             className="mb-4 flex justify-center rounded-lg bg-red-100 p-4 text-sm text-red-700 dark:bg-red-200 dark:text-red-800"
             role="alert"
           >
-            <span className="font-medium">No users are available.</span>
+            <span className="font-medium">{message}</span>
           </div>
         ) : (
           <DialogContent>

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -25,8 +25,10 @@ import { ChatPasswordForm } from 'components/chat/utils/ChatPasswordForm';
 type Props = {
   room: Chatroom;
   open: boolean;
+  isAdmin: boolean;
   onClose: () => void;
   deleteRoom: () => void;
+  leaveRoom: () => void;
   addFriend: (friendId: number) => void;
   addAdmin: (userId: number) => void;
   changePassword: (
@@ -47,8 +49,10 @@ type PasswordForm = {
 export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   room,
   open,
+  isAdmin,
   onClose,
   deleteRoom,
+  leaveRoom,
   addFriend,
   addAdmin,
   changePassword,
@@ -131,12 +135,16 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     switch (selectedRoomSetting) {
       case ChatroomSetting.ADD_FRIEND:
         void fetchFriends(user.id);
+        break;
       case ChatroomSetting.SET_ADMIN:
         void fetchCanSetAdminUsers();
+        break;
       case ChatroomSetting.BAN_USER:
         void fetchCanBanUsers();
+        break;
       case ChatroomSetting.MUTE_USER:
         void fetchCanMuteUsers();
+        break;
       default:
     }
   }, [selectedRoomSetting]);
@@ -192,6 +200,9 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       case ChatroomSetting.DELETE_ROOM:
         deleteRoom();
         break;
+      case ChatroomSetting.LEAVE_ROOM:
+        leaveRoom();
+        break;
       case ChatroomSetting.ADD_FRIEND:
         addFriend(Number(selectedUserId));
         break;
@@ -212,6 +223,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   };
 
   const passwordHelper = 'Must be min 5 characters';
+  const isOwner = room.ownerId === user.id;
 
   return (
     <>
@@ -221,7 +233,8 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
           <FormControl sx={{ mx: 3, my: 1, minWidth: 200 }}>
             <InputLabel id="room-setting-select-label">Setting</InputLabel>
             <ChatroomSettingItems
-              isOwner={room.ownerId === user.id}
+              isAdmin={isAdmin}
+              isOwner={isOwner}
               roomType={room.type}
               selectedRoomSetting={selectedRoomSetting}
               handleChangeSetting={handleChangeSetting}

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { useForm, SubmitHandler } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
-import { Chatroom, ChatroomSetting, ChatUser } from 'types/chat';
+import { Chatroom, ChatroomSetting, ChatUser, ChatroomType } from 'types/chat';
 import { Friend } from 'types/friend';
 import { fetchJoinableFriends } from 'api/friend/fetchJoinableFriends';
 import { fetchChatroomNormalUsers } from 'api/chat/fetchChatroomNormalUsers';
@@ -61,8 +61,18 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   muteUser,
 }: Props) {
   const { data: user } = useQueryUser();
+
+  /**
+   * DMの場合はDeleteのみ選択できる
+   * その他にルームは共通してLeaveが選択できる
+   */
+  const initRoomSettingState =
+    room.type === ChatroomType.DM
+      ? ChatroomSetting.DELETE_ROOM
+      : ChatroomSetting.LEAVE_ROOM;
+
   const [selectedRoomSetting, setSelectedRoomSetting] =
-    useState<ChatroomSetting>(ChatroomSetting.LEAVE_ROOM);
+    useState<ChatroomSetting>(initRoomSettingState);
   const [selectedUserId, setSelectedUserId] = useState('');
   const [notAdminUsers, setNotAdminUsers] = useState<ChatUser[]>([]);
   const [notBannedUsers, setNotBannedUsers] = useState<ChatUser[]>([]);
@@ -193,7 +203,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   };
 
   const handleClose = () => {
-    setSelectedRoomSetting(ChatroomSetting.LEAVE_ROOM);
+    setSelectedRoomSetting(initRoomSettingState);
     initDialog();
     onClose();
   };

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -251,6 +251,32 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     handleClose();
   };
 
+  const isSelectTarget = () => {
+    return selectedUserId !== '';
+  };
+  const isDisableButton = () => {
+    switch (selectedRoomSetting) {
+      case ChatroomSetting.DELETE_ROOM:
+        return false;
+      case ChatroomSetting.LEAVE_ROOM:
+        // ownerかつ選択できる場合はユーザーを選択しないとボタンを表示しない
+        if (room.ownerId !== user.id) return false;
+        if (activeUsers.length === 0) return false;
+
+        return !isSelectTarget();
+      case ChatroomSetting.ADD_FRIEND:
+        return !isSelectTarget();
+      case ChatroomSetting.SET_ADMIN:
+        return !isSelectTarget();
+      case ChatroomSetting.CHANGE_PASSWORD:
+        return false;
+      case ChatroomSetting.MUTE_USER:
+        return !isSelectTarget();
+      case ChatroomSetting.BAN_USER:
+        return !isSelectTarget();
+    }
+  };
+
   const passwordHelper = 'Must be min 5 characters';
   const isOwner = room.ownerId === user.id;
 
@@ -279,7 +305,6 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
             message="If you leave this room, it will be deleted."
           />
         )}
-
         {selectedRoomSetting === ChatroomSetting.ADD_FRIEND && (
           <ChatroomSettingDetailDialog
             users={friends}
@@ -349,6 +374,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
           </Button>
           <Button
             onClick={handleSubmit(handleAction) as VoidFunction}
+            disabled={isDisableButton()}
             variant="contained"
           >
             OK

--- a/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
@@ -71,18 +71,16 @@ export const ChatroomSettingItems = memo(function ChatroomSettingItems({
       <MenuItem value={ChatroomSetting.LEAVE_ROOM}>
         {ChatroomSetting.LEAVE_ROOM}
       </MenuItem>
-      {isAdmin ||
-        (isOwner && (
-          <MenuItem value={ChatroomSetting.MUTE_USER}>
-            {ChatroomSetting.MUTE_USER}
-          </MenuItem>
-        ))}
-      {isAdmin ||
-        (isOwner && (
-          <MenuItem value={ChatroomSetting.BAN_USER}>
-            {ChatroomSetting.BAN_USER}
-          </MenuItem>
-        ))}
+      {(isAdmin || isOwner) && (
+        <MenuItem value={ChatroomSetting.MUTE_USER}>
+          {ChatroomSetting.MUTE_USER}
+        </MenuItem>
+      )}
+      {(isAdmin || isOwner) && (
+        <MenuItem value={ChatroomSetting.BAN_USER}>
+          {ChatroomSetting.BAN_USER}
+        </MenuItem>
+      )}
       {isOwner && (
         <MenuItem value={ChatroomSetting.DELETE_ROOM}>
           {ChatroomSetting.DELETE_ROOM}

--- a/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
@@ -3,6 +3,7 @@ import { Select, SelectChangeEvent, MenuItem } from '@mui/material';
 import { ChatroomSetting, ChatroomType } from 'types/chat';
 
 type Props = {
+  isAdmin: boolean;
   isOwner: boolean;
   roomType: ChatroomType;
   selectedRoomSetting: ChatroomSetting;
@@ -37,12 +38,14 @@ const DMSettingItems = memo(function DMSettingItems({
 /**
  * ユーザーのタイプ：Owner, Admin, Normal
  * - チャットルームを削除する： Owner, DMの場合はAdminも可能
+ * - チャットルームを退出する： 全てのユーザーが実行可能
  * - adminを設定する：Owner
  * - friendを入室させる：PrivateかつOwnerのみ
  * - ミュートする：Owner, Admin（DMでは表示しない）
  * - BANする：Owner, Admin（DMでは表示しない）
  */
 export const ChatroomSettingItems = memo(function ChatroomSettingItems({
+  isAdmin,
   isOwner,
   roomType,
   selectedRoomSetting,
@@ -65,12 +68,21 @@ export const ChatroomSettingItems = memo(function ChatroomSettingItems({
       label="setting"
       onChange={handleChangeSetting}
     >
-      <MenuItem value={ChatroomSetting.MUTE_USER}>
-        {ChatroomSetting.MUTE_USER}
+      <MenuItem value={ChatroomSetting.LEAVE_ROOM}>
+        {ChatroomSetting.LEAVE_ROOM}
       </MenuItem>
-      <MenuItem value={ChatroomSetting.BAN_USER}>
-        {ChatroomSetting.BAN_USER}
-      </MenuItem>
+      {isAdmin ||
+        (isOwner && (
+          <MenuItem value={ChatroomSetting.MUTE_USER}>
+            {ChatroomSetting.MUTE_USER}
+          </MenuItem>
+        ))}
+      {isAdmin ||
+        (isOwner && (
+          <MenuItem value={ChatroomSetting.BAN_USER}>
+            {ChatroomSetting.BAN_USER}
+          </MenuItem>
+        ))}
       {isOwner && (
         <MenuItem value={ChatroomSetting.DELETE_ROOM}>
           {ChatroomSetting.DELETE_ROOM}

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -41,7 +41,7 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       setMessages([]);
       setCurrentRoomId(0);
       // socketの退出処理をする
-      socket.emit('chat:leaveRoom');
+      socket.emit('chat:leaveSocket');
       // 所属しているチャットルーム一覧を取得する
       socket.emit('chat:getJoinedRooms', user.id);
     });

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -49,7 +49,7 @@ const Chat: NextPage = () => {
       setMessages([]);
       setCurrentRoomId(NOT_JOINED_ROOM);
       // socketの退出処理をする
-      socket.emit('chat:leaveRoom');
+      socket.emit('chat:leaveSocket');
       // 所属しているチャットルーム一覧を取得する
       socket.emit('chat:getJoinedRooms', user.id);
     });

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -37,6 +37,7 @@ export type ChatroomType = typeof ChatroomType[keyof typeof ChatroomType];
 
 export const ChatroomSetting = {
   DELETE_ROOM: 'Delete Room',
+  LEAVE_ROOM: 'Leave Room',
   ADD_FRIEND: 'Add Friend', // private room
   CHANGE_PASSWORD: 'Change Password', // protected room
   SET_ADMIN: 'Set Admin',


### PR DESCRIPTION
## 概要
- 設定項目からチャットルームを退出できるようにした
- オーナーだった場合は次の2パターンに分岐する
  - 他にユーザーが入室していない または MUTE or BANされているユーザーしかいない -> チャットルームを削除する
  - 他にユーザーが入室している -> 誰か一人をオーナーに指定する
- DMは退出ボタンを表示しない

## 動作確認
- **[user1]** チャットルームを作成する
- **[user2]** 入室する
- **[user1]** Leave roomを選択する際に次のチャットルームオーナーを選択すると退出できる
  - ※表示されない場合はリロードしてください。
- **[user2]** 他に入室しているユーザーが存在しないので、退出するとチャットルームが削除される
  - ※表示されない場合はリロードしてください。

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/195

## demo

https://user-images.githubusercontent.com/76232929/209926108-92ac7e32-8c1a-4bb7-ad1e-58af623fa5ff.mov


