### PR TITLE
/game/homeのprofileに表示されるユーザー名のalignmentの修正

### DIFF
--- a/frontend/components/game/home/Profile.tsx
+++ b/frontend/components/game/home/Profile.tsx
@@ -82,7 +82,13 @@ export const Profile = () => {
             />
           </Grid>
           <Grid item sx={{ width: '75%' }}>
-            <Typography noWrap gutterBottom variant="h5" component="div">
+            <Typography
+              noWrap
+              gutterBottom
+              variant="h5"
+              component="div"
+              align="center"
+            >
               {user.name}
             </Typography>
           </Grid>


### PR DESCRIPTION
赤囲いの部分が左揃えになってしまっていたので、中央揃えになるように修正

<img width="1792" alt="Screen Shot 2022-12-29 at 2 40 14" src="https://user-images.githubusercontent.com/15176241/209851531-0944f73f-9779-4ead-8ee4-ba0db4ff1f82.png">
