### PR TITLE
Ongoing Battleの表示崩れの修正

### DIFF
--- a/frontend/components/game/battle/Setting.tsx
+++ b/frontend/components/game/battle/Setting.tsx
@@ -9,6 +9,7 @@ import {
   FormControl,
   FormLabel,
 } from '@mui/material';
+import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useSocketStore } from 'store/game/ClientSocket';
 import { useGameSettingStore } from 'store/game/GameSetting';
@@ -29,6 +30,7 @@ export const Setting = () => {
   const [countDown, updateCountDown] = useState(durationOfSettingInSec);
   const player1DefaultScore = 0;
   const player2DefaultScore = 0;
+  const router = useRouter();
 
   const handleDifficultySetting = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value: unknown = e.target.value;
@@ -81,6 +83,28 @@ export const Setting = () => {
       player2Score: player2DefaultScore,
     });
   };
+
+  useEffect(() => {
+    const cancelOngoingBattle = () => {
+      socket.emit('cancelOngoingBattle');
+    };
+
+    router.events.on('routeChangeStart', cancelOngoingBattle);
+
+    return () => {
+      router.events.off('routeChangeStart', cancelOngoingBattle);
+    };
+  });
+
+  useEffect(() => {
+    socket.on('cancelOngoingBattle', () => {
+      updatePlayState(PlayState.stateCanceled);
+    });
+
+    return () => {
+      socket.off('cancelOngoingBattle');
+    };
+  }, [socket]);
 
   return (
     <Grid item>

--- a/frontend/components/game/home/Display.tsx
+++ b/frontend/components/game/home/Display.tsx
@@ -51,27 +51,27 @@ export const Display = () => {
         justifyContent="center"
         alignItems="stretch"
         direction="row"
-        spacing={4}
+        spacing={3}
         sx={{ mt: 1, height: 800 }}
       >
-        <Grid item xs={5}>
+        <Grid item xs={5} sx={{ minWidth: '430px' }}>
           <Paper elevation={2} sx={{ height: '100%' }}>
             <Profile />
           </Paper>
         </Grid>
-        <Grid item xs={5}>
+        <Grid item xs={5} sx={{ minWidth: '430px' }}>
           <Paper elevation={2} sx={{ height: '100%' }}>
             {playState === PlayState.stateNothing && <Start />}
             {(playState === PlayState.stateWaiting ||
               playState === PlayState.statePlaying) && <Wait />}
           </Paper>
         </Grid>
-        <Grid item xs={5} sx={{ height: '60%' }}>
+        <Grid item xs={5} sx={{ height: '60%', minWidth: '430px' }}>
           <Paper elevation={2} sx={{ height: '100%' }}>
             <History userId={user.id} />
           </Paper>
         </Grid>
-        <Grid item xs={5} sx={{ height: '60%' }}>
+        <Grid item xs={5} sx={{ height: '60%', minWidth: '430px' }}>
           <Paper elevation={2} sx={{ height: '100%' }}>
             <Watch />
           </Paper>

--- a/frontend/components/game/home/Watch.tsx
+++ b/frontend/components/game/home/Watch.tsx
@@ -102,7 +102,16 @@ export const Watch = () => {
 
   return (
     <>
-      <Typography variant="h2" align="center" gutterBottom noWrap>
+      <Typography
+        variant="h2"
+        align="center"
+        gutterBottom
+        noWrap
+        sx={{
+          mx: 'auto',
+          width: '95%',
+        }}
+      >
         Ongoing Battles
       </Typography>
       <List

--- a/frontend/components/game/home/Watch.tsx
+++ b/frontend/components/game/home/Watch.tsx
@@ -102,7 +102,7 @@ export const Watch = () => {
 
   return (
     <>
-      <Typography variant="h2" align="center" gutterBottom>
+      <Typography variant="h2" align="center" gutterBottom noWrap>
         Ongoing Battles
       </Typography>
       <List

--- a/frontend/components/game/home/Watch.tsx
+++ b/frontend/components/game/home/Watch.tsx
@@ -6,6 +6,7 @@ import {
   Typography,
   Tooltip,
   IconButton,
+  Pagination,
 } from '@mui/material';
 import { useMutationStatus } from 'hooks/useMutationStatus';
 import { useQueryUser } from 'hooks/useQueryUser';
@@ -38,6 +39,7 @@ export const Watch = () => {
   const router = useRouter();
   const { data: user } = useQueryUser();
   const { updateStatusMutation } = useMutationStatus();
+  const [page, setPage] = useState(1);
 
   useEffect(() => {
     if (user === undefined) return;
@@ -92,13 +94,21 @@ export const Watch = () => {
     updatePlayerNames(playerNames);
   };
 
+  const handleChange = (event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value);
+  };
+
+  const take = 5;
+
   return (
     <>
       <Typography variant="h2" align="center" gutterBottom>
         Ongoing Battles
       </Typography>
-      <List sx={{ width: '95%', margin: 'auto' }}>
-        {rooms?.map((room) => (
+      <List
+        sx={{ width: '95%', margin: 'auto', overflow: 'auto', height: '310px' }}
+      >
+        {rooms?.slice((page - 1) * take, page * take).map((room) => (
           <ListItem
             key={room.roomName}
             sx={{ border: '1px solid' }}
@@ -146,6 +156,16 @@ export const Watch = () => {
           </ListItem>
         ))}
       </List>
+      <Pagination
+        count={Math.ceil(rooms?.length / take)}
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          textAlign: 'center',
+        }}
+        page={page}
+        onChange={handleChange}
+      />
     </>
   );
 };


### PR DESCRIPTION
# 概要

* `Play.tsx` と同じようにゲームの設定画面(`Setting.tsx`)でも戻るボタンを押すとゲームをキャンセルするようにしました。
(動作見た限りで大丈夫だと思ってますが、この変更が良くなかったら教えてください。)
* 必須でもないですが、画面サイズ変えたときに表示崩れがひどかったので`minWidth`つけました
* historyと同様にPaginationにしました。

https://user-images.githubusercontent.com/64348608/209908693-b16e6e87-1c43-4528-86e7-137dd5bd2e72.mp4

https://user-images.githubusercontent.com/64348608/209918337-ed922624-1888-47e2-b6e4-376ed08d5f16.mp4



## resolve

* resolve #235 
* resolve #233 