### PR TITLE
ユーザー名の上限の長さを設定

### DIFF
--- a/backend/.env
+++ b/backend/.env
@@ -9,5 +9,3 @@
 DATABASE_URL="postgresql://user:pass@localhost:5434/dbname/?schema=public"
 JWT_SECRET='mSSS9Zrd'
 AVATAR_IMAGE_DIR="./uploads/avatarImages"
-USERNAME_MAX_LEN="50"
-PASSWORD_MIN_LEN="5"

--- a/backend/.env
+++ b/backend/.env
@@ -9,3 +9,5 @@
 DATABASE_URL="postgresql://user:pass@localhost:5434/dbname/?schema=public"
 JWT_SECRET='mSSS9Zrd'
 AVATAR_IMAGE_DIR="./uploads/avatarImages"
+USERNAME_MAX_LEN="50"
+PASSWORD_MIN_LEN="5"

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -1,7 +1,7 @@
 import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
 
-const passwordMinLen = Number(process.env.PASSWORD_MIN_LEN);
-const usernameMaxLen = Number(process.env.USERNAME_MAX_LEN);
+const passwordMinLen = 5;
+const usernameMaxLen = 50;
 
 export class AuthDto {
   @IsString()

--- a/backend/src/auth/dto/auth.dto.ts
+++ b/backend/src/auth/dto/auth.dto.ts
@@ -1,11 +1,16 @@
-import { IsNotEmpty, IsString, MinLength } from 'class-validator';
+import { IsNotEmpty, IsString, MinLength, MaxLength } from 'class-validator';
+
+const passwordMinLen = Number(process.env.PASSWORD_MIN_LEN);
+const usernameMaxLen = Number(process.env.USERNAME_MAX_LEN);
+
 export class AuthDto {
   @IsString()
   @IsNotEmpty()
-  @MinLength(5)
+  @MinLength(passwordMinLen)
   password: string;
 
   @IsString()
   @IsNotEmpty()
+  @MaxLength(usernameMaxLen)
   username: string;
 }

--- a/backend/src/user/dto/update-name.dto.ts
+++ b/backend/src/user/dto/update-name.dto.ts
@@ -1,7 +1,10 @@
-import { IsNotEmpty, IsString } from 'class-validator';
+import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
+
+const username_max_len = Number(process.env.USERNAME_MAX_LEN);
 
 export class UpdateNameDto {
   @IsString()
   @IsNotEmpty()
+  @MaxLength(username_max_len)
   name: string;
 }

--- a/backend/src/user/dto/update-name.dto.ts
+++ b/backend/src/user/dto/update-name.dto.ts
@@ -1,10 +1,10 @@
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-const username_max_len = Number(process.env.USERNAME_MAX_LEN);
+const usernameMaxLen = Number(process.env.USERNAME_MAX_LEN);
 
 export class UpdateNameDto {
   @IsString()
   @IsNotEmpty()
-  @MaxLength(username_max_len)
+  @MaxLength(usernameMaxLen)
   name: string;
 }

--- a/backend/src/user/dto/update-name.dto.ts
+++ b/backend/src/user/dto/update-name.dto.ts
@@ -1,6 +1,6 @@
 import { IsNotEmpty, IsString, MaxLength } from 'class-validator';
 
-const usernameMaxLen = Number(process.env.USERNAME_MAX_LEN);
+const usernameMaxLen = 50;
 
 export class UpdateNameDto {
   @IsString()

--- a/frontend/.env
+++ b/frontend/.env
@@ -7,5 +7,3 @@
 DATABASE_URL="postgresql://user:pass@localhost:5434/dbname/?schema=public"
 JWT_SECRET='mSSS9Zrd'
 NEXT_PUBLIC_API_URL=http://localhost:3001
-USERNAME_MAX_LEN="50"
-PASSWORD_MIN_LEN="5"

--- a/frontend/.env
+++ b/frontend/.env
@@ -7,4 +7,5 @@
 DATABASE_URL="postgresql://user:pass@localhost:5434/dbname/?schema=public"
 JWT_SECRET='mSSS9Zrd'
 NEXT_PUBLIC_API_URL=http://localhost:3001
-
+USERNAME_MAX_LEN="50"
+PASSWORD_MIN_LEN="5"

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -27,10 +27,20 @@ import * as z from 'zod';
 import { Loading } from 'components/common/Loading';
 import Head from 'next/head';
 
+const usernameMaxLen = Number(process.env.USERNAME_MAX_LEN);
+const passwordMinLen = Number(process.env.USERNAME_MAX_LEN);
+
 // username, passwordのvalidation
 const schema = z.object({
-  username: z.string().min(1, { message: 'No username provided' }),
-  password: z.string().min(5, { message: 'Password should be min 5 chars' }),
+  username: z
+    .string()
+    .min(1, { message: 'No username provided' })
+    .max(usernameMaxLen, {
+      message: `Username must be shorter than or equal to ${usernameMaxLen} characters`,
+    }),
+  password: z.string().min(passwordMinLen, {
+    message: `Password should be min ${passwordMinLen} chars`,
+  }),
 });
 
 const Home: NextPage = () => {

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -27,8 +27,8 @@ import * as z from 'zod';
 import { Loading } from 'components/common/Loading';
 import Head from 'next/head';
 
-const usernameMaxLen = Number(process.env.USERNAME_MAX_LEN);
-const passwordMinLen = Number(process.env.USERNAME_MAX_LEN);
+const usernameMaxLen = 50;
+const passwordMinLen = 5;
 
 // username, passwordのvalidation
 const schema = z.object({

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -24,14 +24,14 @@ import { AxiosError } from 'axios';
 import { AxiosErrorResponse } from 'types';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
 
-const username_max_len = Number(process.env.USERNAME_MAX_LEN);
+const usernameMaxLen = 50;
 
 const schema = z.object({
   username: z
     .string()
     .min(1, { message: 'Username cannot be empty' })
-    .max(username_max_len, {
-      message: `Username must be shorter than or equal to ${username_max_len} characters`,
+    .max(usernameMaxLen, {
+      message: `Username must be shorter than or equal to ${usernameMaxLen} characters`,
     }),
 });
 

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -24,8 +24,15 @@ import { AxiosError } from 'axios';
 import { AxiosErrorResponse } from 'types';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
 
+const username_max_len = Number(process.env.USERNAME_MAX_LEN);
+
 const schema = z.object({
-  username: z.string().min(1, { message: 'Username cannot be empty' }),
+  username: z
+    .string()
+    .min(1, { message: 'Username cannot be empty' })
+    .max(username_max_len, {
+      message: `Username must be shorter than or equal to ${username_max_len} characters`,
+    }),
 });
 
 const Setting: NextPage = () => {


### PR DESCRIPTION
## 概要

- ユーザー名の上限の長さを50文字に設定
- 上限値の設定については.envで管理
- ついでにパスワードの最短の長さも.envで管理するように変更

## 動作確認

- 50文字を超えるユーザー名のユーザーを作成しようとするとエラーが出るか確認
- Settingでユーザー名を50文字以上に変更しようとする際にエラーが出るか確認

## 関連イシュー

- resolve #223 