### PR TITLE
2FAの登録・解除

### DIFF
--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -8,6 +8,7 @@ import {
   Req,
   Get,
   Param,
+  Patch,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
@@ -98,12 +99,9 @@ export class AuthController {
     return this.authService.generateQrCode(Number(id));
   }
 
-  @Post('send2facode')
-  send2FACode(
-    @Param('id') id: string,
-    @Body() dto: Validate2FACodeDto,
-  ): Promise<string> {
-    return this.authService.send2FACode(Number(id), dto);
+  @Patch('send2facode')
+  send2FACode(@Body() dto: Validate2FACodeDto): Promise<string> {
+    return this.authService.send2FACode(dto);
   }
 
   @Get('has2fa')
@@ -129,8 +127,8 @@ export class AuthController {
     };
   }
 
-  @Post('disable2fa')
-  disable2FA(@Body() data: Validate2FACodeDto): Promise<string> {
-    return this.authService.disable2FA(data);
+  @Patch('disable2fa')
+  disable2FA(@Body() dto: Validate2FACodeDto): Promise<string> {
+    return this.authService.disable2FA(dto);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -100,12 +100,12 @@ export class AuthController {
   }
 
   @Patch('send2facode')
-  send2FACode(@Body() dto: Validate2FACodeDto): Promise<string> {
+  send2FACode(@Body() dto: Validate2FACodeDto): Promise<boolean> {
     return this.authService.send2FACode(dto);
   }
 
   @Get('has2fa')
-  has2FA(@Param('id') id: string): Promise<string> {
+  has2FA(@Param('id') id: string): Promise<boolean> {
     return this.authService.has2FA(Number(id));
   }
 
@@ -113,7 +113,7 @@ export class AuthController {
   async validate2FA(
     @Body() dto: Validate2FACodeDto,
     @Res({ passthrough: true }) res: Response,
-  ): Promise<Msg> {
+  ): Promise<boolean> {
     const jwt = await this.authService.validate2FA(dto);
     res.cookie('access_token', jwt.accessToken, {
       httpOnly: true,
@@ -122,13 +122,11 @@ export class AuthController {
       path: '/',
     });
 
-    return {
-      message: 'ok',
-    };
+    return true;
   }
 
   @Patch('disable2fa')
-  disable2FA(@Body() dto: Validate2FACodeDto): Promise<string> {
+  disable2FA(@Body() dto: Validate2FACodeDto): Promise<boolean> {
     return this.authService.disable2FA(dto);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -125,8 +125,8 @@ export class AuthController {
     return true;
   }
 
-  @Patch('disable2fa')
-  disable2FA(@Body() dto: Validate2FACodeDto): Promise<boolean> {
-    return this.authService.disable2FA(dto);
+  @Patch('disable2fa/:id')
+  disable2FA(@Param('id') id: string): Promise<boolean> {
+    return this.authService.disable2FA(id);
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -127,6 +127,6 @@ export class AuthController {
 
   @Patch('disable2fa/:id')
   disable2FA(@Param('id') id: string): Promise<boolean> {
-    return this.authService.disable2FA(id);
+    return this.authService.disable2FA(Number(id));
   }
 }

--- a/backend/src/auth/auth.controller.ts
+++ b/backend/src/auth/auth.controller.ts
@@ -9,6 +9,7 @@ import {
   Get,
   Param,
   Patch,
+  ParseIntPipe,
 } from '@nestjs/common';
 import { Request, Response } from 'express';
 import { AuthService } from './auth.service';
@@ -95,8 +96,8 @@ export class AuthController {
   // API for 2Factor Auth
   //
   @Get('qr2fa/:id')
-  generateQrCode(@Param('id') id: string): Promise<string> {
-    return this.authService.generateQrCode(Number(id));
+  generateQrCode(@Param('id', ParseIntPipe) id: number): Promise<string> {
+    return this.authService.generateQrCode(id);
   }
 
   @Patch('send2facode')
@@ -105,8 +106,8 @@ export class AuthController {
   }
 
   @Get('has2fa')
-  has2FA(@Param('id') id: string): Promise<boolean> {
-    return this.authService.has2FA(Number(id));
+  has2FA(@Param('id', ParseIntPipe) id: number): Promise<boolean> {
+    return this.authService.has2FA(id);
   }
 
   @Post('validate2fa')
@@ -126,7 +127,7 @@ export class AuthController {
   }
 
   @Patch('disable2fa/:id')
-  disable2FA(@Param('id') id: string): Promise<boolean> {
-    return this.authService.disable2FA(Number(id));
+  disable2FA(@Param('id', ParseIntPipe) id: number): Promise<boolean> {
+    return this.authService.disable2FA(id);
   }
 }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -209,7 +209,7 @@ export class AuthService {
 
   async send2FACode(dto: Validate2FACodeDto): Promise<boolean> {
     // ユーザーのシークレットを取得
-    const userSecret = this.preAuthSecrets.get(Number(dto.userId));
+    const userSecret = this.preAuthSecrets.get(dto.userId);
     const valid = speakeasy.totp.verify({
       secret: userSecret,
       token: dto.code,
@@ -266,11 +266,11 @@ export class AuthService {
     return this.generateJwt(user.id, user.name);
   }
 
-  async disable2FA(id: string): Promise<boolean> {
+  async disable2FA(id: number): Promise<boolean> {
     try {
       const user_db = await this.prisma.user.update({
         where: {
-          id: Number(id),
+          id: id,
         },
         data: {
           has2FA: false,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -200,11 +200,11 @@ export class AuthService {
       label: user.name,
       issuer: 'ft_transcendence',
     });
-    const qr_code = qrcode.toDataURL(url);
+    const qrCode = qrcode.toDataURL(url);
     // 一時的にシークレットを保存
     this.preAuthSecrets.set(userId, secretBase32);
 
-    return qr_code;
+    return qrCode;
   }
 
   async send2FACode(dto: Validate2FACodeDto): Promise<boolean> {
@@ -219,16 +219,16 @@ export class AuthService {
     }
     //2FAの登録が完了したら、2FA機能をオンにして登録
     try {
-      const user_db = await this.prisma.user.update({
+      await this.prisma.user.update({
         where: {
-          id: Number(dto.userId),
+          id: dto.userId,
         },
         data: {
           has2FA: true,
           secret2FA: userSecret,
         },
       });
-      this.preAuthSecrets.delete(Number(dto.userId));
+      this.preAuthSecrets.delete(dto.userId);
     } catch {
       return false;
     }
@@ -252,7 +252,7 @@ export class AuthService {
   async validate2FA(data: Validate2FACodeDto): Promise<Jwt> {
     const user = await this.prisma.user.findUnique({
       where: {
-        id: Number(data.userId),
+        id: data.userId,
       },
     });
     const valid = speakeasy.totp.verify({
@@ -268,7 +268,7 @@ export class AuthService {
 
   async disable2FA(id: number): Promise<boolean> {
     try {
-      const user_db = await this.prisma.user.update({
+      await this.prisma.user.update({
         where: {
           id: id,
         },

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -262,10 +262,10 @@ export class AuthService {
     return this.generateJwt(user.id, user.name);
   }
 
-  async disable2FA(data: Validate2FACodeDto): Promise<boolean> {
+  async disable2FA(id: string): Promise<boolean> {
     const user_db = await this.prisma.user.update({
       where: {
-        id: Number(data.userId),
+        id: Number(id),
       },
       data: {
         has2FA: false,

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -218,16 +218,20 @@ export class AuthService {
       return false;
     }
     //2FAの登録が完了したら、2FA機能をオンにして登録
-    const user_db = await this.prisma.user.update({
-      where: {
-        id: Number(dto.userId),
-      },
-      data: {
-        has2FA: true,
-        secret2FA: userSecret,
-      },
-    });
-    this.preAuthSecrets.delete(Number(dto.userId));
+    try {
+      const user_db = await this.prisma.user.update({
+        where: {
+          id: Number(dto.userId),
+        },
+        data: {
+          has2FA: true,
+          secret2FA: userSecret,
+        },
+      });
+      this.preAuthSecrets.delete(Number(dto.userId));
+    } catch {
+      return false;
+    }
 
     return true;
   }
@@ -263,15 +267,19 @@ export class AuthService {
   }
 
   async disable2FA(id: string): Promise<boolean> {
-    const user_db = await this.prisma.user.update({
-      where: {
-        id: Number(id),
-      },
-      data: {
-        has2FA: false,
-        secret2FA: '',
-      },
-    });
+    try {
+      const user_db = await this.prisma.user.update({
+        where: {
+          id: Number(id),
+        },
+        data: {
+          has2FA: false,
+          secret2FA: '',
+        },
+      });
+    } catch {
+      return false;
+    }
 
     return true;
   }

--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -207,7 +207,7 @@ export class AuthService {
     return qr_code;
   }
 
-  async send2FACode(dto: Validate2FACodeDto): Promise<string> {
+  async send2FACode(dto: Validate2FACodeDto): Promise<boolean> {
     // ユーザーのシークレットを取得
     const userSecret = this.preAuthSecrets.get(Number(dto.userId));
     const valid = speakeasy.totp.verify({
@@ -215,7 +215,7 @@ export class AuthService {
       token: dto.code,
     });
     if (!valid) {
-      return 'failure';
+      return false;
     }
     //2FAの登録が完了したら、2FA機能をオンにして登録
     const user_db = await this.prisma.user.update({
@@ -229,20 +229,19 @@ export class AuthService {
     });
     this.preAuthSecrets.delete(Number(dto.userId));
 
-    return 'success';
+    return true;
   }
 
-  async has2FA(userId: number): Promise<string> {
+  async has2FA(userId: number): Promise<boolean> {
     const user = await this.prisma.user.findUnique({
       where: {
         id: userId,
       },
     });
-    // TODO: 戻り値がstringで良いか、frontendの実装時に再検討予定
     if (user.has2FA) {
-      return 'enabled: true';
+      return true;
     } else {
-      return 'enabled: false';
+      return false;
     }
   }
 
@@ -263,7 +262,7 @@ export class AuthService {
     return this.generateJwt(user.id, user.name);
   }
 
-  async disable2FA(data: Validate2FACodeDto): Promise<string> {
+  async disable2FA(data: Validate2FACodeDto): Promise<boolean> {
     const user_db = await this.prisma.user.update({
       where: {
         id: Number(data.userId),
@@ -274,7 +273,6 @@ export class AuthService {
       },
     });
 
-    // TODO: 戻り値がstringで良いか、frontendの実装時に再検討予定
-    return 'disabled: true';
+    return true;
   }
 }

--- a/backend/src/auth/dto/validate-2FACode.dto.ts
+++ b/backend/src/auth/dto/validate-2FACode.dto.ts
@@ -1,9 +1,14 @@
-import { IsNotEmpty, IsString, IsNumberString } from 'class-validator';
+import {
+  IsNumber,
+  IsNotEmpty,
+  IsString,
+  IsNumberString,
+} from 'class-validator';
 
 export class Validate2FACodeDto {
-  @IsString()
+  @IsNumber()
   @IsNotEmpty()
-  userId: string;
+  userId: number;
 
   @IsString()
   @IsNotEmpty()

--- a/backend/src/auth/dto/validate-2FACode.dto.ts
+++ b/backend/src/auth/dto/validate-2FACode.dto.ts
@@ -1,9 +1,8 @@
-import { IsNotEmpty, IsString, IsUUID, IsNumberString } from 'class-validator';
+import { IsNotEmpty, IsString, IsNumberString } from 'class-validator';
 
 export class Validate2FACodeDto {
   @IsString()
   @IsNotEmpty()
-  @IsUUID()
   userId: string;
 
   @IsString()

--- a/frontend/hooks/useMutationHas2FA.tsx
+++ b/frontend/hooks/useMutationHas2FA.tsx
@@ -1,0 +1,74 @@
+import axios, { AxiosError } from 'axios';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/router';
+
+export const useMutationHas2FA = () => {
+  const queryClient = useQueryClient();
+  const router = useRouter();
+
+  const enableHas2FAMutation = useMutation<
+    string, // 戻り値の型
+    AxiosError,
+    { userId: number; authCode: string } //mutate実行時の引数
+  >(
+    async ({ userId, authCode }) => {
+      const { data } = await axios.patch<string>(
+        `${process.env.NEXT_PUBLIC_API_URL as string}/auth/send2facode`,
+        {
+          userId: String(userId),
+          code: authCode,
+        },
+      );
+
+      return data; //この場合、success,failureが返る。
+    },
+    {
+      onSuccess: (res) => {
+        if (res == 'success') {
+          queryClient.removeQueries(['user']);
+          void router.push('/setting'); //登録が成功したらsettingに戻る
+        } else {
+          console.log('Register ERROR Please Retry');
+          // TODO: できたらここで失敗したアラート表示
+        }
+      },
+      onError: (err: AxiosError) => {
+        console.log(err);
+        throw err;
+      },
+    },
+  );
+
+  const disableHas2FAMutation = useMutation<
+    string,
+    AxiosError,
+    { userId: number }
+  >(
+    async ({ userId }) => {
+      const { data } = await axios.patch<string>(
+        `${process.env.NEXT_PUBLIC_API_URL as string}/auth/disable2fa`,
+        {
+          userId: String(userId),
+          code: '1234', //登録時と同じ型を使うためダミーの値を設定している
+        },
+      );
+
+      return data;
+    },
+    {
+      onSuccess: (res) => {
+        if (res == 'disabled: true') {
+          //TODO: 登録解除したアラート出したい
+          console.log('Successs Disabled');
+          console.log(res);
+          queryClient.removeQueries(['user']);
+        }
+      },
+      onError: (err: AxiosError) => {
+        console.log(err);
+      },
+    },
+  );
+
+  return { enableHas2FAMutation, disableHas2FAMutation };
+};

--- a/frontend/hooks/useMutationHas2FA.tsx
+++ b/frontend/hooks/useMutationHas2FA.tsx
@@ -9,7 +9,7 @@ export const useMutationHas2FA = () => {
   const changeHas2FAMutation = useMutation<
     boolean, // 戻り値の型
     AxiosError,
-    { isEnable: boolean; userId: number; authCode: string } //mutate実行時の引数
+    { isEnable: boolean; userId: number; authCode: number } //mutate実行時の引数
   >(
     async ({ isEnable, userId, authCode }) => {
       if (isEnable) {
@@ -17,7 +17,7 @@ export const useMutationHas2FA = () => {
         const { data } = await axios.patch<boolean>(
           `${process.env.NEXT_PUBLIC_API_URL as string}/auth/send2facode`,
           {
-            userId: String(userId),
+            userId: userId,
             code: authCode,
           },
         );

--- a/frontend/hooks/useMutationHas2FA.tsx
+++ b/frontend/hooks/useMutationHas2FA.tsx
@@ -9,7 +9,7 @@ export const useMutationHas2FA = () => {
   const changeHas2FAMutation = useMutation<
     boolean, // 戻り値の型
     AxiosError,
-    { isEnable: boolean; userId: number; authCode: number } //mutate実行時の引数
+    { isEnable: boolean; userId: number; authCode: string } //mutate実行時の引数
   >(
     async ({ isEnable, userId, authCode }) => {
       if (isEnable) {

--- a/frontend/hooks/useMutationHas2FA.tsx
+++ b/frontend/hooks/useMutationHas2FA.tsx
@@ -45,8 +45,7 @@ export const useMutationHas2FA = () => {
       },
       onError: (err: AxiosError) => {
         // codeに数字以外が含まれる場合
-        console.log(err);
-        throw err;
+        throw new Error(err.message);
       },
     },
   );

--- a/frontend/hooks/useMutationHas2FA.tsx
+++ b/frontend/hooks/useMutationHas2FA.tsx
@@ -7,12 +7,12 @@ export const useMutationHas2FA = () => {
   const router = useRouter();
 
   const enableHas2FAMutation = useMutation<
-    string, // 戻り値の型
+    boolean, // 戻り値の型
     AxiosError,
     { userId: number; authCode: string } //mutate実行時の引数
   >(
     async ({ userId, authCode }) => {
-      const { data } = await axios.patch<string>(
+      const { data } = await axios.patch<boolean>(
         `${process.env.NEXT_PUBLIC_API_URL as string}/auth/send2facode`,
         {
           userId: String(userId),
@@ -20,11 +20,11 @@ export const useMutationHas2FA = () => {
         },
       );
 
-      return data; //この場合、success,failureが返る。
+      return data;
     },
     {
       onSuccess: (res) => {
-        if (res == 'success') {
+        if (res == true) {
           queryClient.removeQueries(['user']);
           void router.push('/setting'); //登録が成功したらsettingに戻る
         } else {
@@ -41,12 +41,12 @@ export const useMutationHas2FA = () => {
   );
 
   const disableHas2FAMutation = useMutation<
-    string,
+    boolean,
     AxiosError,
     { userId: number }
   >(
     async ({ userId }) => {
-      const { data } = await axios.patch<string>(
+      const { data } = await axios.patch<boolean>(
         `${process.env.NEXT_PUBLIC_API_URL as string}/auth/disable2fa`,
         {
           userId: String(userId),
@@ -58,7 +58,7 @@ export const useMutationHas2FA = () => {
     },
     {
       onSuccess: (res) => {
-        if (res == 'disabled: true') {
+        if (res == true) {
           queryClient.removeQueries(['user']);
         }
       },

--- a/frontend/hooks/useMutationHas2FA.tsx
+++ b/frontend/hooks/useMutationHas2FA.tsx
@@ -28,11 +28,12 @@ export const useMutationHas2FA = () => {
           queryClient.removeQueries(['user']);
           void router.push('/setting'); //登録が成功したらsettingに戻る
         } else {
-          console.log('Register ERROR Please Retry');
-          // TODO: できたらここで失敗したアラート表示
+          // codeの数字が間違った場合
+          throw new Error('Register ERROR Please Retry');
         }
       },
       onError: (err: AxiosError) => {
+        // codeに数字以外が含まれる場合
         console.log(err);
         throw err;
       },
@@ -58,9 +59,6 @@ export const useMutationHas2FA = () => {
     {
       onSuccess: (res) => {
         if (res == 'disabled: true') {
-          //TODO: 登録解除したアラート出したい
-          console.log('Successs Disabled');
-          console.log(res);
           queryClient.removeQueries(['user']);
         }
       },

--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -24,7 +24,7 @@ export default NextAuth({
     jwt({ token, account }) {
       // async jwt({ token, user, account, profile, isNewUser }) {
       if (account?.accessToken) {
-        token.accessToken = account.accessToken;
+        token.accessToken = account.accessToken as string;
       }
 
       return token;

--- a/frontend/pages/authenticate.tsx
+++ b/frontend/pages/authenticate.tsx
@@ -13,7 +13,7 @@ const Authenticate = () => {
         if (process.env.NEXT_PUBLIC_API_URL) {
           if (session && session.user !== undefined && session.user !== null) {
             let login = '';
-            let image_url = '';
+            let imageUrl = '';
             console.log(session);
             if (
               session.user.email &&
@@ -21,17 +21,17 @@ const Authenticate = () => {
             ) {
               // gmailでのログインの場合
               login = session.user.email;
-              if (session.user.image) image_url = session.user.image;
+              if (session.user.image) imageUrl = session.user.image;
             } else if (session.user.email) {
               // TODO: 42のアカウントでは、access_tokenからログインIDと画像を取得する必要がある。別PRで対応
               login = session.user.email;
-              image_url = '';
+              imageUrl = '';
             }
             const url_oauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
             await axios
               .post(url_oauth, {
                 oAuthId: login,
-                imagePath: image_url,
+                imagePath: imageUrl,
               })
               .then((res) => {
                 console.log(res);

--- a/frontend/pages/authenticate.tsx
+++ b/frontend/pages/authenticate.tsx
@@ -1,0 +1,67 @@
+import axios from 'axios';
+import { useRouter } from 'next/router';
+import { useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+import { Loading } from 'components/common/Loading';
+
+const Authenticate = () => {
+  const router = useRouter();
+  const { data: session, status } = useSession();
+  useEffect(() => {
+    const f = async () => {
+      if (status === 'authenticated') {
+        if (process.env.NEXT_PUBLIC_API_URL) {
+          if (session && session.user !== undefined && session.user !== null) {
+            let login = '';
+            let image_url = '';
+            console.log(session);
+            if (
+              session.user.email &&
+              session.user.email.indexOf('gmail.com') !== -1
+            ) {
+              // gmailでのログインの場合
+              login = session.user.email;
+              if (session.user.image) image_url = session.user.image;
+            } else {
+              // 42の場合、user情報を取得
+              type Image = {
+                link: string;
+              };
+              type UserInfo = {
+                login: string;
+                image: Image;
+              };
+              const url_getdata =
+                'https://api.intra.42.fr/v2/users/' + String(session.user.id);
+              const response = await axios.get<UserInfo>(url_getdata, {
+                headers: {
+                  Authorization: 'Bearer ' + String(session.user.access_token),
+                },
+              });
+              login = response.data.login;
+              image_url = response.data.image.link;
+            }
+            const url_oauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
+            await axios
+              .post(url_oauth, {
+                oAuthId: login,
+                imagePath: image_url,
+              })
+              .then((res) => {
+                console.log(res);
+                void router.push('/dashboard');
+              })
+              .catch((err) => {
+                console.log(err);
+              });
+          }
+        }
+      }
+    };
+    void f();
+  }, []);
+
+  return <Loading fullHeight={true} />;
+};
+
+export default Authenticate;

--- a/frontend/pages/authenticate.tsx
+++ b/frontend/pages/authenticate.tsx
@@ -12,7 +12,7 @@ const Authenticate = () => {
       if (status === 'authenticated') {
         if (process.env.NEXT_PUBLIC_API_URL) {
           if (session && session.user !== undefined && session.user !== null) {
-            let login = '';
+            let loginName = '';
             let imageUrl = '';
             console.log(session);
             if (
@@ -20,17 +20,17 @@ const Authenticate = () => {
               session.user.email.indexOf('gmail.com') !== -1
             ) {
               // gmailでのログインの場合
-              login = session.user.email;
+              loginName = session.user.email;
               if (session.user.image) imageUrl = session.user.image;
             } else if (session.user.email) {
               // TODO: 42のアカウントでは、access_tokenからログインIDと画像を取得する必要がある。別PRで対応
-              login = session.user.email;
+              loginName = session.user.email;
               imageUrl = '';
             }
-            const url_oauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
+            const urlOauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
             await axios
-              .post(url_oauth, {
-                oAuthId: login,
+              .post(urlOauth, {
+                oAuthId: loginName,
                 imagePath: imageUrl,
               })
               .then((res) => {

--- a/frontend/pages/authenticate.tsx
+++ b/frontend/pages/authenticate.tsx
@@ -8,7 +8,7 @@ const Authenticate = () => {
   const router = useRouter();
   const { data: session, status } = useSession();
   useEffect(() => {
-    const f = async () => {
+    const oauthLogin = async () => {
       if (status === 'authenticated') {
         if (process.env.NEXT_PUBLIC_API_URL) {
           if (session && session.user !== undefined && session.user !== null) {
@@ -44,7 +44,7 @@ const Authenticate = () => {
         }
       }
     };
-    void f();
+    void oauthLogin();
   }, []);
 
   return <Loading fullHeight={true} />;

--- a/frontend/pages/authenticate.tsx
+++ b/frontend/pages/authenticate.tsx
@@ -22,24 +22,27 @@ const Authenticate = () => {
               // gmailでのログインの場合
               login = session.user.email;
               if (session.user.image) image_url = session.user.image;
-            } else {
+            } else if (session.user.email) {
+              login = session.user.email;
+              image_url = '';
+              // TODO: ここ以下は、Sessionの肩拡張が終わったら有効にする. lint対策で一時的にコメントアウト
               // 42の場合、user情報を取得
-              type Image = {
-                link: string;
-              };
-              type UserInfo = {
-                login: string;
-                image: Image;
-              };
-              const url_getdata =
-                'https://api.intra.42.fr/v2/users/' + String(session.user.id);
-              const response = await axios.get<UserInfo>(url_getdata, {
-                headers: {
-                  Authorization: 'Bearer ' + String(session.user.access_token),
-                },
-              });
-              login = response.data.login;
-              image_url = response.data.image.link;
+              // type Image = {
+              //   link: string;
+              // };
+              // type UserInfo = {
+              //   login: string;
+              //   image: Image;
+              // };
+              // const url_getdata =
+              //   'https://api.intra.42.fr/v2/users/' + String(session.user.id);
+              // const response = await axios.get<UserInfo>(url_getdata, {
+              //   headers: {
+              //     Authorization: 'Bearer ' + String(session.user.access_token),
+              //   },
+              // });
+              // login = response.data.login;
+              // image_url = response.data.image.link;
             }
             const url_oauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
             await axios

--- a/frontend/pages/authenticate.tsx
+++ b/frontend/pages/authenticate.tsx
@@ -23,26 +23,9 @@ const Authenticate = () => {
               login = session.user.email;
               if (session.user.image) image_url = session.user.image;
             } else if (session.user.email) {
+              // TODO: 42のアカウントでは、access_tokenからログインIDと画像を取得する必要がある。別PRで対応
               login = session.user.email;
               image_url = '';
-              // TODO: ここ以下は、Sessionの肩拡張が終わったら有効にする. lint対策で一時的にコメントアウト
-              // 42の場合、user情報を取得
-              // type Image = {
-              //   link: string;
-              // };
-              // type UserInfo = {
-              //   login: string;
-              //   image: Image;
-              // };
-              // const url_getdata =
-              //   'https://api.intra.42.fr/v2/users/' + String(session.user.id);
-              // const response = await axios.get<UserInfo>(url_getdata, {
-              //   headers: {
-              //     Authorization: 'Bearer ' + String(session.user.access_token),
-              //   },
-              // });
-              // login = response.data.login;
-              // image_url = response.data.image.link;
             }
             const url_oauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
             await axios

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -36,7 +36,6 @@ const schema = z.object({
 const Home: NextPage = () => {
   const router = useRouter();
   const [isRegister, setIsRegister] = useState(false);
-  const [tryLogin, setTryLogin] = useState(false);
   const [error, setError] = useState<string[]>([]);
   const [showPassword, setShowPassword] = useState(false);
 
@@ -82,46 +81,12 @@ const Home: NextPage = () => {
     }
   };
 
-  const oauthLogin = async () => {
-    if (process.env.NEXT_PUBLIC_API_URL) {
-      if (!session || session.user === null || session.user === undefined) {
-        return;
-      } else {
-        try {
-          reset();
-          // console.log(session.user);
-          const url_oauth = `${process.env.NEXT_PUBLIC_API_URL}/auth/oauth-login`;
-          if (session.user) {
-            await axios.post(url_oauth, {
-              oAuthId: session.user.email,
-              // oAuthId: session.user.oAuthId,
-              imagePath: session.user.image,
-            });
-          }
-          await router.push('/dashboard');
-        } catch (e) {
-          console.log('[OAuth] signup failure: catch');
-          if (axios.isAxiosError(e) && e.response && e.response.data) {
-            reset();
-            const messages = (e.response.data as AxiosErrorResponse).message;
-            if (Array.isArray(messages)) setError(messages);
-            else setError([messages]);
-          }
-        }
-      }
-    }
-  };
-
   if (status === 'loading') {
     return <Loading fullHeight={true} />;
-  }
-
-  if (status === 'authenticated') {
-    if (tryLogin == false) {
-      setTryLogin(true);
-      void (async () => {
-        await oauthLogin();
-      })();
+  } else if (status === 'authenticated') {
+    if (session && session.user !== null && session.user !== undefined) {
+      // void signOut();
+      void router.push('/authenticate');
     }
 
     return <Loading fullHeight={true} />;
@@ -245,28 +210,32 @@ const Home: NextPage = () => {
           <br />
           <Grid container justifyContent="space-evenly">
             <Grid item>
-              <Image
-                src="/images/ico-42-logo.jpg"
-                onClick={() => {
-                  void (async () => {
-                    await signIn('42-school');
-                  })();
-                }}
-                width={50}
-                height={50}
-              />
+              <Button>
+                <Image
+                  src="/images/ico-42-logo.jpg"
+                  onClick={() => {
+                    void (async () => {
+                      await signIn('42-school');
+                    })();
+                  }}
+                  width={50}
+                  height={50}
+                />
+              </Button>
             </Grid>
             <Grid item>
-              <Image
-                src="/images/ico-google-logo-96.png"
-                onClick={() => {
-                  void (async () => {
-                    await signIn('google');
-                  })();
-                }}
-                width={50}
-                height={50}
-              />
+              <Button>
+                <Image
+                  src="/images/ico-google-logo-96.png"
+                  onClick={() => {
+                    void (async () => {
+                      await signIn('google');
+                    })();
+                  }}
+                  width={50}
+                  height={50}
+                />
+              </Button>
             </Grid>
           </Grid>
         </Grid>

--- a/frontend/pages/setting/enable2fa.tsx
+++ b/frontend/pages/setting/enable2fa.tsx
@@ -32,8 +32,8 @@ const Enable2FA: NextPage = () => {
           if (response) {
             setQrCode(response.data);
           }
-        } catch (e) {
-          console.log(e);
+        } catch {
+          throw new Error('Can not get QR Code Exception.');
         }
       }
     };

--- a/frontend/pages/setting/enable2fa.tsx
+++ b/frontend/pages/setting/enable2fa.tsx
@@ -19,7 +19,7 @@ const Enable2FA: NextPage = () => {
   } = useForm<TwoAuthForm>();
   const { data: user } = useQueryUser();
   const [qrCode, setQrCode] = useState('');
-  const { enableHas2FAMutation } = useMutationHas2FA();
+  const { changeHas2FAMutation } = useMutationHas2FA();
   const [openSnack, setOpenSnack] = useState('');
 
   const onCreateComponent = async (): Promise<void> => {
@@ -52,8 +52,9 @@ const Enable2FA: NextPage = () => {
   const onSubmit: SubmitHandler<TwoAuthForm> = (data: TwoAuthForm) => {
     clearErrors();
     if (user !== undefined) {
-      enableHas2FAMutation.mutate(
+      changeHas2FAMutation.mutate(
         {
+          isEnable: true,
           userId: user.id,
           authCode: data.authCode,
         },

--- a/frontend/pages/setting/enable2fa.tsx
+++ b/frontend/pages/setting/enable2fa.tsx
@@ -20,7 +20,7 @@ const Enable2FA: NextPage = () => {
   const { data: user } = useQueryUser();
   const [qrCode, setQrCode] = useState('');
   const { enableHas2FAMutation } = useMutationHas2FA();
-  const [openSnack, setOpenSnack] = useState('none');
+  const [openSnack, setOpenSnack] = useState('');
 
   const onCreateComponent = async (): Promise<void> => {
     if (process.env.NEXT_PUBLIC_API_URL && user) {
@@ -42,7 +42,7 @@ const Enable2FA: NextPage = () => {
   }
 
   const handleClose = () => {
-    setOpenSnack('none');
+    setOpenSnack('');
   };
 
   const on2FAMutationEnableError = () => {
@@ -119,7 +119,7 @@ const Enable2FA: NextPage = () => {
                     clearErrors();
                   }}
                 >
-                  REGISTERED
+                  REGISTER
                 </Button>
                 <Snackbar
                   open={openSnack == 'SUCCESS'}

--- a/frontend/pages/setting/enable2fa.tsx
+++ b/frontend/pages/setting/enable2fa.tsx
@@ -2,7 +2,7 @@ import type { NextPage } from 'next';
 import { Grid, Button, TextField, Snackbar, Alert } from '@mui/material';
 import { Layout } from 'components/common/Layout';
 import Image from 'next/image';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useQueryUser } from 'hooks/useQueryUser';
 import axios from 'axios';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
@@ -22,24 +22,23 @@ const Enable2FA: NextPage = () => {
   const { changeHas2FAMutation } = useMutationHas2FA();
   const [openSnack, setOpenSnack] = useState('');
 
-  const onCreateComponent = async (): Promise<void> => {
-    if (process.env.NEXT_PUBLIC_API_URL && user) {
-      try {
-        const response = await axios.get<string>(
-          `${process.env.NEXT_PUBLIC_API_URL}/auth/qr2fa/${user.id}`,
-        );
-        if (response) {
-          setQrCode(response.data);
+  useEffect(() => {
+    const getQrcode = async () => {
+      if (process.env.NEXT_PUBLIC_API_URL && user) {
+        try {
+          const response = await axios.get<string>(
+            `${process.env.NEXT_PUBLIC_API_URL}/auth/qr2fa/${user.id}`,
+          );
+          if (response) {
+            setQrCode(response.data);
+          }
+        } catch (e) {
+          console.log(e);
         }
-      } catch (e) {
-        console.log(e);
       }
-    }
-  };
-
-  if (qrCode == '') {
-    void onCreateComponent();
-  }
+    };
+    void getQrcode();
+  }, []);
 
   const handleClose = () => {
     setOpenSnack('');

--- a/frontend/pages/setting/enable2fa.tsx
+++ b/frontend/pages/setting/enable2fa.tsx
@@ -1,0 +1,127 @@
+import type { NextPage } from 'next';
+import { Grid, Button, TextField } from '@mui/material';
+import { Layout } from 'components/common/Layout';
+import Image from 'next/image';
+import { useState } from 'react';
+import { useQueryUser } from 'hooks/useQueryUser';
+import axios from 'axios';
+import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import { TwoAuthForm } from 'types/setting';
+import { useMutationHas2FA } from 'hooks/useMutationHas2FA';
+
+const Enable2FA: NextPage = () => {
+  const {
+    control,
+    register,
+    handleSubmit,
+    formState: { errors },
+    clearErrors,
+  } = useForm<TwoAuthForm>();
+  const { data: user } = useQueryUser();
+  const [qrCode, setQrCode] = useState('');
+  const { enableHas2FAMutation } = useMutationHas2FA();
+
+  const onCreateComponent = async (): Promise<void> => {
+    if (process.env.NEXT_PUBLIC_API_URL && user) {
+      try {
+        const response = await axios.get<string>(
+          `${process.env.NEXT_PUBLIC_API_URL}/auth/qr2fa/${user.id}`,
+        );
+        if (response) {
+          setQrCode(response.data);
+        }
+      } catch (e) {
+        console.log(e);
+      }
+    }
+  };
+
+  if (qrCode == '') {
+    void onCreateComponent();
+  }
+
+  const onSubmit: SubmitHandler<TwoAuthForm> = (data: TwoAuthForm) => {
+    clearErrors();
+    if (process.env.NEXT_PUBLIC_API_URL && user !== undefined) {
+      enableHas2FAMutation.mutate({
+        userId: user.id,
+        authCode: data.authCode,
+      });
+    }
+  };
+
+  //実行時にQRコードを取得
+  return (
+    <Layout title="Auth">
+      <Grid
+        container
+        justifyContent="center"
+        direction="column"
+        alignItems="center"
+        sx={{ width: 360 }}
+      >
+        <Grid item>
+          {/* QRコード */}
+          {qrCode != '' && (
+            <Image src={qrCode} width={200} height={200} alt="2FA QR Code" />
+          )}
+        </Grid>
+        <Grid item>
+          <form onSubmit={handleSubmit(onSubmit) as VoidFunction}>
+            <Grid
+              container
+              alignItems="center"
+              justifyContent="center"
+              sx={{ p: 2 }}
+              spacing={2}
+            >
+              <Grid
+                container
+                alignItems="center"
+                justifyContent="center"
+                spacing={2}
+                sx={{ p: 2 }}
+              >
+                {/* 認証コード入力欄 */}
+                <Grid item>
+                  <Controller
+                    name="authCode"
+                    control={control}
+                    render={() => (
+                      <TextField
+                        // eslint-disable-next-line react/jsx-props-no-spreading
+                        {...register('authCode')}
+                        fullWidth
+                        required
+                        id="auth-code"
+                        label="Enter Code from Your Apps"
+                        autoComplete="new-password"
+                        error={errors.authCode ? true : false}
+                        helperText={errors.authCode?.message}
+                        sx={{ my: 2 }}
+                      />
+                    )}
+                  />
+                </Grid>
+                {/* 登録ボタン */}
+                <Grid item>
+                  <Button
+                    variant="contained"
+                    type="submit"
+                    onClick={() => {
+                      clearErrors();
+                    }}
+                  >
+                    REGISTERED
+                  </Button>
+                </Grid>
+              </Grid>
+            </Grid>
+          </form>
+        </Grid>
+      </Grid>
+    </Layout>
+  );
+};
+
+export default Enable2FA;

--- a/frontend/pages/setting/enable2fa.tsx
+++ b/frontend/pages/setting/enable2fa.tsx
@@ -123,15 +123,6 @@ const Enable2FA: NextPage = () => {
                   REGISTER
                 </Button>
                 <Snackbar
-                  open={openSnack == 'SUCCESS'}
-                  autoHideDuration={6000}
-                  onClose={handleClose}
-                >
-                  <Alert onClose={handleClose} severity="success">
-                    2 Factor Auth is enabled!
-                  </Alert>
-                </Snackbar>
-                <Snackbar
                   open={openSnack == 'ERROR'}
                   autoHideDuration={6000}
                   onClose={handleClose}

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -147,7 +147,7 @@ const Setting: NextPage = () => {
       changeHas2FAMutation.mutate({
         isEnable: false,
         userId: user.id,
-        authCode: '',
+        authCode: 0,
       });
       setOpenSnack('OK');
     }

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -61,7 +61,7 @@ const Setting: NextPage = () => {
   });
   const { updateNameMutation } = useMutationName();
   const { updateAvatarMutation, deleteAvatarMutation } = useMutationAvatar();
-  const { disableHas2FAMutation } = useMutationHas2FA();
+  const { changeHas2FAMutation } = useMutationHas2FA();
   const router = useRouter();
 
   if (user === undefined) return <Loading fullHeight />;
@@ -143,8 +143,10 @@ const Setting: NextPage = () => {
   const handleDialogClose = (result: string) => {
     setOpenConfirm(false);
     if (result == 'agree') {
-      disableHas2FAMutation.mutate({
+      changeHas2FAMutation.mutate({
+        isEnable: false,
         userId: user.id,
+        authCode: '',
       });
       setOpenSnack('OK');
     }

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -147,7 +147,7 @@ const Setting: NextPage = () => {
       changeHas2FAMutation.mutate({
         isEnable: false,
         userId: user.id,
-        authCode: 0,
+        authCode: '',
       });
       setOpenSnack('OK');
     }

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -332,11 +332,6 @@ const Setting: NextPage = () => {
           </Grid>
         </Grid>
       </form>
-      {/* <Grid container alignItems="center" justifyContent="center" spacing={2}>
-        <Grid item>
-          <Enable2FA></Enable2FA>
-        </Grid>
-      </Grid> */}
     </Layout>
   );
 };

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -301,8 +301,17 @@ const Setting: NextPage = () => {
                 </DialogContentText>
               </DialogContent>
               <DialogActions>
-                <Button onClick={() => handleDialogClose('agree')}>OK</Button>
-                <Button onClick={() => handleDialogClose('disagree')} autoFocus>
+                <Button
+                  onClick={() => handleDialogClose('agree')}
+                  variant="contained"
+                >
+                  YES
+                </Button>
+                <Button
+                  onClick={() => handleDialogClose('disagree')}
+                  variant="outlined"
+                  autoFocus
+                >
                   NO
                 </Button>
               </DialogActions>

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -64,7 +64,8 @@ const Setting: NextPage = () => {
   const { changeHas2FAMutation } = useMutationHas2FA();
   const router = useRouter();
 
-  if (user === undefined) return <Loading fullHeight />;
+  if (user === undefined || router.isReady === false)
+    return <Loading fullHeight />;
 
   const avatarImageUrl = getAvatarImageUrl(user.id);
 

--- a/frontend/pages/setting/index.tsx
+++ b/frontend/pages/setting/index.tsx
@@ -23,6 +23,8 @@ import { Loading } from 'components/common/Loading';
 import { AxiosError } from 'axios';
 import { AxiosErrorResponse } from 'types';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
+import { useRouter } from 'next/router';
+import { useMutationHas2FA } from 'hooks/useMutationHas2FA';
 
 const schema = z.object({
   username: z.string().min(1, { message: 'Username cannot be empty' }),
@@ -44,6 +46,8 @@ const Setting: NextPage = () => {
   });
   const { updateNameMutation } = useMutationName();
   const { updateAvatarMutation, deleteAvatarMutation } = useMutationAvatar();
+  const { disableHas2FAMutation } = useMutationHas2FA();
+  const router = useRouter();
 
   if (user === undefined) return <Loading fullHeight />;
 
@@ -108,6 +112,17 @@ const Setting: NextPage = () => {
         userId: user.id,
         avatarPath: user.avatarPath,
       });
+    }
+  };
+
+  const onChange2faSetting = async () => {
+    if (user.has2FA) {
+      //TODO: 確認ダイアログを出した後に解除したい
+      disableHas2FAMutation.mutate({
+        userId: user.id,
+      });
+    } else {
+      await router.push('/setting/enable2fa');
     }
   };
 
@@ -220,7 +235,31 @@ const Setting: NextPage = () => {
             </Button>
           </Grid>
         </Grid>
+        <Grid
+          container
+          alignItems="center"
+          justifyContent="center"
+          spacing={2}
+          sx={{ p: 2 }}
+        >
+          <Grid item>
+            <Button
+              variant="contained"
+              component="label"
+              onClick={() => {
+                void onChange2faSetting();
+              }}
+            >
+              {user.has2FA ? 'DISABLE 2FA' : 'ENABLE 2FA'}
+            </Button>
+          </Grid>
+        </Grid>
       </form>
+      {/* <Grid container alignItems="center" justifyContent="center" spacing={2}>
+        <Grid item>
+          <Enable2FA></Enable2FA>
+        </Grid>
+      </Grid> */}
     </Layout>
   );
 };

--- a/frontend/types/setting.ts
+++ b/frontend/types/setting.ts
@@ -3,5 +3,5 @@ export type SettingForm = {
 };
 
 export type TwoAuthForm = {
-  authCode: string;
+  authCode: number;
 };

--- a/frontend/types/setting.ts
+++ b/frontend/types/setting.ts
@@ -3,5 +3,5 @@ export type SettingForm = {
 };
 
 export type TwoAuthForm = {
-  authCode: number;
+  authCode: string;
 };

--- a/frontend/types/setting.ts
+++ b/frontend/types/setting.ts
@@ -1,3 +1,7 @@
 export type SettingForm = {
   username: string;
 };
+
+export type TwoAuthForm = {
+  authCode: string;
+};


### PR DESCRIPTION
* Resolve #167  
* Resolve #179 

## 変更の概要

* settingから、2FA機能の有効・無効を設定できるようにした

## なぜこの変更をするのか

* 2要素認証の実装のため、登録と解除を先行して実装。

## やったこと

* [x] setting画面へ、2FA登録・解除ボタン（共通）を追加
* [x] 2FA機能の登録画面を作成(enable2fa.tsx)
* [x] 2FAの登録処理
* [x] 2FAの解除処理
* [x] 2FA登録・解除後のユーザー情報キャッシュの更新 (useMutationHas2FA.tsx)
* [x] 登録時の認証コードエラーメッセージ、解除完了のメッセージ、解除確認ダイアログを表示
* [x] トップのOAuth認証用アイコンのボタン化

## 変更内容

* setting画面のENABLE2FA（DISABLE2FAと兼用）ボタンを押下した時の動作
* 登録直後に「登録完了しました」などのアラート、 登録解除前に「解除しますか？」のダイアログと、「解除しました」のアラートなどを表示
* トップのindexで実施していたoauth認証の処理を別ファイルに移動(authenticate.tsx)
* トップの42,GoogleのOAuth用イメージがボタンのように指マークになって押せるようにした

## 影響範囲

* DBへのカラム追加などはありません。Userのhas2FA、secret2FAの値を使用するようになります。

## どうやるのか

<登録>
* setting画面で、ENABLE2FAボタンを押下
* Google AuthenticatorのインストールされたスマートフォンでQRコードを読み込み
* 6桁のコードを画面に入力し、登録ボタンを押下
* setting画面に戻り、2FAボタンがDISABLEの表示に変化している

<解除>
* setting画面で、DISABLEボタンを押下。
* 確認ダイアログでOKを押す
* setting画面で、2FAボタンがENABLEの表示に戻っている

## 課題

* ログイン時の認証（次のPRで）
* [...nextauth].ts のlintエラー（年末に相談した件）

## 備考
