### PR TITLE
docker-compose時のOAuth signup errorの解消

### DIFF
--- a/frontend/pages/api/auth/[...nextauth].ts
+++ b/frontend/pages/api/auth/[...nextauth].ts
@@ -30,4 +30,5 @@ export default NextAuth({
       return token;
     },
   },
+  secret: process.env.JWT_SECRET,
 });


### PR DESCRIPTION
## 概要

#245 で報告したエラーを解消しました。
ただ動作確認についてはGoogle OAuthの方でお願いします。理由については備考を参照ください。

## 備考

ローカルで試したところ、この修正を施しても、下記の動画の通り、42のOAuthの方はサインアップしようとしてもずっとLoadingになってしまう現象が発生しました。
ただ、現在、Kohrakuさんが出して頂いているPRがマージされれば、このLoadingされ続ける現象は解消される気がするので、一旦、それがマージされるのを待って、現象が継続するようであれば、改めてイシューを上げたいと思います。

https://user-images.githubusercontent.com/15176241/210175526-693dd432-b173-48b0-88d3-0e114d82e883.mov

## 関連イシュー

- resolve #245 