### PR TITLE
/chat でリロードするとROOMの表示、作成ができなくなる。 

### DIFF
--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -27,7 +27,7 @@ const Chat: NextPage = () => {
   useEffect(() => {
     const temp = io('ws://localhost:3001/chat');
     setSocket(temp);
-    // if (temp.disconnected) temp.connect();
+    if (temp.disconnected) temp.connect();
 
     return () => {
       temp.disconnect();

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -27,6 +27,7 @@ const Chat: NextPage = () => {
   useEffect(() => {
     const temp = io('ws://localhost:3001/chat');
     setSocket(temp);
+    // if (temp.disconnected) temp.connect();
 
     return () => {
       temp.disconnect();


### PR DESCRIPTION
# 概要

* https://github.com/ryo-manba/ft_transcendence/issues/249

の修正です。対症療法ではありますがとりあえずはこれで行きたいです。

# 動作確認

issueで上げたバグが修正されていること。
`make`したのち`/chat`でリロードしたときにROOMが表示されていることを確認お願いします。

resolve #249 