### PR TITLE
[WIP]チャットルームの名前とメッセージの文字数の上限値を超えたらエラーにする

### DIFF
--- a/backend/src/chat/dto/create-chatroom.dto.ts
+++ b/backend/src/chat/dto/create-chatroom.dto.ts
@@ -4,12 +4,16 @@ import {
   IsString,
   IsEnum,
   IsOptional,
+  MaxLength,
 } from 'class-validator';
 import { ChatroomType } from '@prisma/client';
+
+const maxChatroomNameLength = 100;
 
 export class CreateChatroomDto {
   @IsString()
   @IsNotEmpty()
+  @MaxLength(maxChatroomNameLength)
   name: string;
 
   @IsEnum(ChatroomType)

--- a/backend/src/chat/dto/create-message.dto.ts
+++ b/backend/src/chat/dto/create-message.dto.ts
@@ -1,4 +1,6 @@
-import { IsNotEmpty, IsInt, IsString } from 'class-validator';
+import { IsNotEmpty, IsInt, IsString, MaxLength } from 'class-validator';
+
+const maxMessageLength = 2000;
 
 export class CreateMessageDto {
   @IsNotEmpty()
@@ -11,5 +13,6 @@ export class CreateMessageDto {
 
   @IsNotEmpty()
   @IsString()
+  @MaxLength(maxMessageLength)
   message: string;
 }


### PR DESCRIPTION
## 概要
- 現状何文字でも受け付けるので、上限値を超える場合はエラーにする

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/273
