### PR TITLE
M1チップでdocker-composeが動くように修正

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.0-alpine
+FROM --platform=linux/amd64 node:16.18.0-alpine
 
 WORKDIR /src
 

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.18.0-alpine
+FROM --platform=linux/amd64 node:16.18.0-alpine
 
 EXPOSE 3000
 


### PR DESCRIPTION
## 概要

#267 への対応です。M1チップだと元のうまくdocker-composeが動いてくれなかったため、Dockerfile内でplatformをlinux/amd64に指定することで、これまで通り動くようにしました。
おそらく不具合はないと思うのですが、皆さんの環境でも動くか試してみてもらいたいです。

## 参考URL

- https://docs.docker.com/engine/reference/builder/#from
- https://www.quora.com/What-is-the-difference-between-ARM64-and-AMD64-And-which-one-is-faster?share=1

## 関連イシュー

- resolve #267 