### PR TITLE
フレンドマッチとランダムマッチの組み合わせたときにおこるバグの修正

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -152,16 +152,18 @@ export class GameGateway {
     return Math.random() * (Math.random() < 0.5 ? 1 : -1);
   }
 
-  updatePlayerStatus(player1: Player, player2: Player) {
+  updatePlayerStatus(player1: Player, player2: Player, gameType: string) {
     const playerNames: [string, string] = [player1.name, player2.name];
+    const select = gameType + ':select';
+    const standby = gameType + ':standBy';
 
     // if both players' points are equal, first player joining the que will select the rule
     if (player1.point <= player2.point) {
-      player1.socket.emit('select', playerNames);
-      player2.socket.emit('standBy', playerNames);
+      player1.socket.emit(select, playerNames);
+      player2.socket.emit(standby, playerNames);
     } else {
-      player1.socket.emit('standBy', playerNames);
-      player2.socket.emit('select', playerNames);
+      player1.socket.emit(standby, playerNames);
+      player2.socket.emit(select, playerNames);
     }
   }
 
@@ -310,7 +312,7 @@ export class GameGateway {
       score: 0,
     };
 
-    void this.startGame(player1, player2);
+    void this.startGame(player1, player2, 'friend');
   }
 
   @SubscribeMessage('playStart')
@@ -345,11 +347,11 @@ export class GameGateway {
         height: GameGateway.initialHeight,
         score: 0,
       };
-      void this.startGame(player1, player2);
+      void this.startGame(player1, player2, 'random');
     }
   }
 
-  async startGame(player1: Player, player2: Player) {
+  async startGame(player1: Player, player2: Player, gameType: string) {
     const roomName = uuidv4();
 
     this.logger.log(`${player1.socket.id} joined to room ${roomName}`);
@@ -386,7 +388,7 @@ export class GameGateway {
 
     this.gameRooms.push(newRoom);
 
-    this.updatePlayerStatus(player1, player2);
+    this.updatePlayerStatus(player1, player2, gameType);
   }
 
   @SubscribeMessage('watchGame')

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -155,14 +155,14 @@ export class GameGateway {
   updatePlayerStatus(player1: Player, player2: Player, gameType: string) {
     const playerNames: [string, string] = [player1.name, player2.name];
     const select = gameType + ':select';
-    const standby = gameType + ':standBy';
+    const standBy = gameType + ':standBy';
 
     // if both players' points are equal, first player joining the que will select the rule
     if (player1.point <= player2.point) {
       player1.socket.emit(select, playerNames);
-      player2.socket.emit(standby, playerNames);
+      player2.socket.emit(standBy, playerNames);
     } else {
-      player1.socket.emit(standby, playerNames);
+      player1.socket.emit(standBy, playerNames);
       player2.socket.emit(select, playerNames);
     }
   }

--- a/frontend/components/common/GameGuest.tsx
+++ b/frontend/components/common/GameGuest.tsx
@@ -92,14 +92,14 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
       }
     };
 
-    socket.on('select', (playerNames: [string, string]) => {
+    socket.on('friend:select', (playerNames: [string, string]) => {
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateSelecting);
 
       updateUserStatusPlaying();
       void router.push('/game/battle');
     });
-    socket.on('standBy', (playerNames: [string, string]) => {
+    socket.on('friend:standBy', (playerNames: [string, string]) => {
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateStandingBy);
 
@@ -108,8 +108,8 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
     });
 
     return () => {
-      socket.off('select');
-      socket.off('standBy');
+      socket.off('friend:select');
+      socket.off('friend:standBy');
     };
   });
 

--- a/frontend/components/common/GameGuest.tsx
+++ b/frontend/components/common/GameGuest.tsx
@@ -97,6 +97,8 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
       updatePlayState(PlayState.stateSelecting);
 
       updateUserStatusPlaying();
+      // cancel random match
+      socket.emit('playCancel');
       void router.push('/game/battle');
     });
     socket.on('friend:standBy', (playerNames: [string, string]) => {
@@ -104,6 +106,8 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
       updatePlayState(PlayState.stateStandingBy);
 
       updateUserStatusPlaying();
+      // cancel random match
+      socket.emit('playCancel');
       void router.push('/game/battle');
     });
 

--- a/frontend/components/game/home/Host.tsx
+++ b/frontend/components/game/home/Host.tsx
@@ -43,7 +43,7 @@ export const Host = () => {
         return;
       }
     };
-    socket.on('select', (playerNames: [string, string]) => {
+    socket.on('friend:select', (playerNames: [string, string]) => {
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateSelecting);
       updateInvitedFriendState({
@@ -53,7 +53,7 @@ export const Host = () => {
       updateUserStatusPlaying();
       void router.push('/game/battle');
     });
-    socket.on('standBy', (playerNames: [string, string]) => {
+    socket.on('friend:standBy', (playerNames: [string, string]) => {
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateStandingBy);
       updateInvitedFriendState({
@@ -69,8 +69,8 @@ export const Host = () => {
     });
 
     return () => {
-      socket.off('select');
-      socket.off('standBy');
+      socket.off('friend:select');
+      socket.off('friend:standBy');
       socket.off('denyInvitation');
     };
   });

--- a/frontend/components/game/home/Wait.tsx
+++ b/frontend/components/game/home/Wait.tsx
@@ -45,14 +45,16 @@ export const Wait = () => {
         return;
       }
     };
-    socket.on('select', (playerNames: [string, string]) => {
+    socket.on('random:select', (playerNames: [string, string]) => {
+      console.log('HELLO');
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateSelecting);
 
       updateUserStatusPlaying();
       void router.push('/game/battle');
     });
-    socket.on('standBy', (playerNames: [string, string]) => {
+    socket.on('random:standBy', (playerNames: [string, string]) => {
+      console.log('HELLO');
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateStandingBy);
 
@@ -61,8 +63,8 @@ export const Wait = () => {
     });
 
     return () => {
-      socket.off('select');
-      socket.off('standBy');
+      socket.off('random:select');
+      socket.off('random:standBy');
     };
   }, [socket, user]);
 

--- a/frontend/components/game/home/Wait.tsx
+++ b/frontend/components/game/home/Wait.tsx
@@ -46,7 +46,6 @@ export const Wait = () => {
       }
     };
     socket.on('random:select', (playerNames: [string, string]) => {
-      console.log('HELLO');
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateSelecting);
 
@@ -54,7 +53,6 @@ export const Wait = () => {
       void router.push('/game/battle');
     });
     socket.on('random:standBy', (playerNames: [string, string]) => {
-      console.log('HELLO');
       updatePlayerNames(playerNames);
       updatePlayState(PlayState.stateStandingBy);
 


### PR DESCRIPTION
# 概要

フレンドマッチとランダムマッチの組み合わせたときにおこるバグを修正しました。



https://user-images.githubusercontent.com/64348608/212529196-58228754-cc36-471f-ba42-d5bbe1b2c91d.mp4

バグは以下の通りです。

* ランダムマッチ待機中でフレンドマッチが成立すると、`socket.off('standBy')`によってランダムマッチ成立のlistenができなくなる。
* ランダムマッチ待機中でフレンドマッチが成立すると、サーバー側(`game.gateway`)のwaitingQueueにソケットが残り続ける。

これがあるとフレンドマッチ成立時にランダムマッチ待機しているとフロントエンドは`Waiting for Opponent`となっているのにゲームができません。

またもともとの動作は以下のissueに載せてあります

* resolve #287 



