### PR TITLE
サイドバーをスクロール可能にした

### DIFF
--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -7,6 +7,7 @@ import { ChatroomJoinButton } from 'components/chat/chatroom/ChatroomJoinButton'
 import { Chatroom, CurrentRoom, Message } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
+import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
 import Debug from 'debug';
 
 type Props = {
@@ -61,23 +62,31 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
   if (user === undefined) {
     return <Loading />;
   }
+  const heightStyle = ChatHeightStyle();
 
   return (
     <>
-      <ChatroomCreateButton socket={socket} setRooms={setRooms} />
-      <ChatroomJoinButton socket={socket} user={user} />
-      <List dense={false}>
-        {rooms &&
-          rooms.map((room, i) => (
-            <ChatroomListItem
-              key={i}
-              room={room}
-              socket={socket}
-              setCurrentRoom={setCurrentRoom}
-              setMessages={setMessages}
-            />
-          ))}
-      </List>
+      <div
+        style={{
+          ...heightStyle,
+          overflow: 'scroll',
+        }}
+      >
+        <ChatroomCreateButton socket={socket} setRooms={setRooms} />
+        <ChatroomJoinButton socket={socket} user={user} />
+        <List dense={false}>
+          {rooms &&
+            rooms.map((room, i) => (
+              <ChatroomListItem
+                key={i}
+                room={room}
+                socket={socket}
+                setCurrentRoom={setCurrentRoom}
+                setMessages={setMessages}
+              />
+            ))}
+        </List>
+      </div>
     </>
   );
 });

--- a/frontend/components/chat/friend/FriendSidebar.tsx
+++ b/frontend/components/chat/friend/FriendSidebar.tsx
@@ -1,14 +1,15 @@
 import { memo, useState, useEffect } from 'react';
 import { List } from '@mui/material';
 import { Socket } from 'socket.io-client';
-import { FriendAddButton } from 'components/chat/friend/FriendAddButton';
-import { FriendListItem } from 'components/chat/friend/FriendListItem';
-import { Loading } from 'components/common/Loading';
-import { useQueryUser } from 'hooks/useQueryUser';
+import Debug from 'debug';
 import { Friend } from 'types/friend';
 import { fetchFollowingUsers } from 'api/friend/fetchFollowingUsers';
+import { useQueryUser } from 'hooks/useQueryUser';
+import { Loading } from 'components/common/Loading';
+import { FriendAddButton } from 'components/chat/friend/FriendAddButton';
+import { FriendListItem } from 'components/chat/friend/FriendListItem';
 import { ChatBlockButton } from 'components/chat/block/ChatBlockButton';
-import Debug from 'debug';
+import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
 
 type Props = {
   socket: Socket;
@@ -50,19 +51,28 @@ export const FriendSidebar = memo(function FriendSidebar({ socket }: Props) {
     };
   }, []);
 
+  const heightStyle = ChatHeightStyle();
+
   return (
     <>
-      <FriendAddButton setFriends={setFriends} />
-      <ChatBlockButton
-        socket={socket}
-        removeFriendById={handleRemoveFriendById}
-      />
-      <List dense={false}>
-        {friends &&
-          friends.map((friend) => (
-            <FriendListItem key={friend.id} friend={friend} socket={socket} />
-          ))}
-      </List>
+      <div
+        style={{
+          ...heightStyle,
+          overflow: 'scroll',
+        }}
+      >
+        <FriendAddButton setFriends={setFriends} />
+        <ChatBlockButton
+          socket={socket}
+          removeFriendById={handleRemoveFriendById}
+        />
+        <List dense={false}>
+          {friends &&
+            friends.map((friend) => (
+              <FriendListItem key={friend.id} friend={friend} socket={socket} />
+            ))}
+        </List>
+      </div>
     </>
   );
 });

--- a/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
@@ -7,6 +7,7 @@ import { Loading } from 'components/common/Loading';
 import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
 import { ChatTextInput } from 'components/chat/message-exchange/ChatTextInput';
 import { ChatMessageList } from 'components/chat/message-exchange/ChatMessageList';
+import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
 
 type Props = {
   socket: Socket;
@@ -56,15 +57,15 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
     });
   };
 
-  const appBarHeight = '64px';
+  const heightStyle = ChatHeightStyle();
 
   return (
     <>
       <Paper
         style={{
+          ...heightStyle,
           display: 'flex',
           flexDirection: 'column',
-          height: `calc(100vh - ${appBarHeight})`,
         }}
       >
         <div

--- a/frontend/components/chat/utils/ChatHeightStyle.ts
+++ b/frontend/components/chat/utils/ChatHeightStyle.ts
@@ -1,0 +1,8 @@
+// appBarを除いた画面の高さを指定するコンポーネント
+const appBarHeight = '64px';
+
+export const ChatHeightStyle = () => {
+  return {
+    height: `calc(100vh - ${appBarHeight})`,
+  };
+};

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -8,8 +8,7 @@ import { FriendSidebar } from 'components/chat/friend/FriendSidebar';
 import { Layout } from 'components/common/Layout';
 import { ChatMessageExchange } from 'components/chat/message-exchange/ChatMessageExchange';
 import { Message, CurrentRoom } from 'types/chat';
-
-const appBarHeight = '64px';
+import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
 
 const Chat: NextPage = () => {
   const [socket, setSocket] = useState<Socket>();
@@ -32,6 +31,8 @@ const Chat: NextPage = () => {
     return null;
   }
 
+  const heightStyle = ChatHeightStyle();
+
   return (
     <Layout title="Chat">
       <Header title="Chatroom" />
@@ -40,7 +41,7 @@ const Chat: NextPage = () => {
         direction="row"
         justifyContent="center"
         alignItems="stretch"
-        style={{ height: `calc(100vh - ${appBarHeight})` }}
+        style={heightStyle}
       >
         <Grid
           xs={2}


### PR DESCRIPTION
## 概要

- サイドバーの表示が溢れる場合に、それに伴って画面全体が下方向にスクロールされてしまっていた
- 画面に表示しきれない分は、スクロールで表示するように変更した
- overflow: scrollをつけることで対応した
- https://developer.mozilla.org/ja/docs/Web/CSS/overflow

## その他
- 追加ボタンなどはスクロールされなくてもいいかなと思ったんですが、heightの計算がややこしくなるため対応していません。

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/295

## demo

https://user-images.githubusercontent.com/76232929/212800138-49ef1bd4-f29b-4617-9df5-71429cae0e1c.mov



