### PR TITLE
作成済みのChatroomに入室すると過去のメッセージが二重に表示されるバグの修正

### DIFF
--- a/frontend/components/chat/message-exchange/ChatMessageList.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageList.tsx
@@ -41,7 +41,7 @@ export const ChatMessageList = memo(function ChatMessageList({
   const loadingMessages = async (
     roomId: number,
     pageSize: number,
-    skip = 0,
+    skip: number,
   ) => {
     const chatMessages = await fetchMessages({
       roomId: roomId,
@@ -66,9 +66,17 @@ export const ChatMessageList = memo(function ChatMessageList({
       },
     );
 
-    setMessages([]);
-    setSkipPage(0);
-    void loadingMessages(currentRoomId, INITIAL_ITEM_COUNT);
+    const setupMessages = async () => {
+      const chatMessages = await fetchMessages({
+        roomId: currentRoomId,
+        skip: 0,
+        pageSize: INITIAL_ITEM_COUNT,
+      });
+      setMessages(chatMessages);
+    };
+    void setupMessages();
+
+    setSkipPage(1);
   }, [currentRoomId]);
 
   const prependMessages = useCallback(() => {


### PR DESCRIPTION
## 概要
- strictModeによって、二度fetchが走るためメッセージが重複してしまっていた
- そこで、初期メッセージ取得時には、取得したメッセージをそのままセットするように修正した

## その他
- メッセージを一度に取得する量を統一した
- これまで未対応だったが、DBからデータをfetchする際にデータをスキップする量を分けなくてはいけなかったため
  - 具体的には初回のみ20件、それ以降10件ずつとしていた
  - 今回の修正によりどちらも20件ずつ取得するように変更した

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/280

## demo

https://user-images.githubusercontent.com/76232929/212825240-40486911-d018-4917-ad48-a7343f8eefcb.mov


