### PR TITLE
ログイン中に戻る操作して別アカウントでログインした場合、後者でログインができるようにする

### DIFF
--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -32,6 +32,7 @@ import * as z from 'zod';
 import { Loading } from 'components/common/Loading';
 import Head from 'next/head';
 import { ValidationDialog } from 'components/auth/ValidationDialog';
+import { useQueryClient } from '@tanstack/react-query';
 
 const usernameMaxLen = 50;
 const passwordMinLen = 5;
@@ -56,6 +57,7 @@ const Home: NextPage = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [openValidationDialog, setOpenValidationDialog] = useState(false);
   const [validationUserId, setValidationUserId] = useState(0);
+  const queryClient = useQueryClient();
 
   const {
     control,
@@ -76,6 +78,7 @@ const Home: NextPage = () => {
   const onSubmit: SubmitHandler<AuthForm> = async (formData: AuthForm) => {
     try {
       if (process.env.NEXT_PUBLIC_API_URL) {
+        queryClient.removeQueries(['user']);
         if (isRegister) {
           const urlSignup = `${process.env.NEXT_PUBLIC_API_URL}/auth/signup`;
           await axios.post(urlSignup, {
@@ -134,7 +137,7 @@ const Home: NextPage = () => {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center">
       <Head>
-        <title>Auth</title>
+        <title>ft_transcendence</title>
       </Head>
       <main className="flex w-screen flex-1 flex-col items-center justify-center">
         <Grid


### PR DESCRIPTION
# 変更点
* ログイン（登録）ボタンを押した時に、useQueryUserのキャッシュをクリアするようにした
* ログインページのタイトルをAuthからft_transcendenceに変更

# 確認して欲しい点
1. 登録済みユーザーでログインし、ダッシュボードに入る
2. ブラウザで←（戻る）を実施し、ログインページに戻る
3. 別ユーザー（登録済み、新規問わず）でログイン（登録）を実施
→ 後者のユーザーでログインできるか。

# 備考
* OAuthでログインした場合は、ログインページにアクセスするとSessionが有効なためdashboardへ自動で遷移する。
* 作成アドレスでログインした場合は、ログインページにアクセスするとそのまま表示される
という動作の違いがあります。

# 解決する課題
* Resolve #296
