### PR TITLE
frontendでマイグレーション実行時にWarningが出ないように修正した

### DIFF
--- a/frontend/prisma/schema.prisma
+++ b/frontend/prisma/schema.prisma
@@ -108,7 +108,7 @@ model User {
 
 model BlockRelation {
   createdAt       DateTime @default(now())
-  updatedAt       DateTime @default(now()) @updatedAt
+  updatedAt       DateTime @default(now())
   blockingUserId  Int
   blockedByUserId Int
   blockedBy       User     @relation("blockedBy", fields: [blockedByUserId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## 概要

**before**
- frontendで `yarn migrate` を実行するとwarningが出ていた

**after**
- frontend側のprisma.schemaから `@updatedAt` を削除することで対応した

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/311