### PR TITLE
複数招待をDenyするときに、一つ目をDenyするとSnackbarが消えるバグの修正

### DIFF
--- a/frontend/components/common/GameGuest.tsx
+++ b/frontend/components/common/GameGuest.tsx
@@ -75,7 +75,7 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
         socket.emit('denyInvitation', match);
       }
     },
-    [user],
+    [user, hosts],
   );
 
   useEffect(() => {


### PR DESCRIPTION
# 概要

https://github.com/ryo-manba/ft_transcendence/issues/318 の修正

https://user-images.githubusercontent.com/64348608/213844272-c89368e1-4f3a-48f3-9ab6-0713a40b97f5.mp4

* resolve #318 