### PR TITLE
同一ユーザの複数ゲームを禁止する。

### DIFF
--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -185,7 +185,8 @@ export class GameGateway {
       this.waitingQueue.find((player) => player.id === id) !== undefined;
     if (isWaitingGame) return true;
 
-    // 招待されているときに例えばゲームを開始しようとするのは問題ない。
+    // 招待されているときに例えばランダムゲームのマッチングを開始するのは問題ない。
+    // つまり、招待されていることを確認する必要はない。
     const isInvitingGame = this.invitationList.find(id) !== undefined;
     if (isInvitingGame) return true;
 

--- a/backend/src/game/game.gateway.ts
+++ b/backend/src/game/game.gateway.ts
@@ -174,6 +174,24 @@ export class GameGateway {
     }
   }
 
+  isStartingGame(id: number): boolean {
+    const isPlayingGame =
+      this.gameRooms.find(
+        (room) => room.player1.id === id || room.player2.id === id,
+      ) !== undefined;
+    if (isPlayingGame) return true;
+
+    const isWaitingGame =
+      this.waitingQueue.find((player) => player.id === id) !== undefined;
+    if (isWaitingGame) return true;
+
+    // 招待されているときに例えばゲームを開始しようとするのは問題ない。
+    const isInvitingGame = this.invitationList.find(id) !== undefined;
+    if (isInvitingGame) return true;
+
+    return false;
+  }
+
   /**
    * 接続と招待者の通知
    * @param socket
@@ -219,6 +237,8 @@ export class GameGateway {
     @ConnectedSocket() socket: Socket,
     @MessageBody() dto: InviteFriendDto,
   ): Promise<boolean> {
+    if (this.isStartingGame(dto.hostId)) return false;
+
     const newInvitation: Invitation = {
       guestId: dto.guestId,
       hostId: dto.hostId,
@@ -280,7 +300,9 @@ export class GameGateway {
   async beginFriendMatch(
     @ConnectedSocket() socket: Socket,
     @MessageBody() dto: AcceptInvitationDto,
-  ) {
+  ): Promise<boolean> {
+    if (this.isStartingGame(dto.guestId)) return false;
+
     const invitation = this.invitationList.find(dto.hostId);
     if (invitation === undefined) return;
 
@@ -318,15 +340,18 @@ export class GameGateway {
       height: GameGateway.initialHeight,
       score: 0,
     };
-
     void this.startGame(player1, player2, 'friend');
+
+    return true;
   }
 
   @SubscribeMessage('playStart')
   async joinRoom(
     @ConnectedSocket() socket: Socket,
     @MessageBody() dto: JoinRoomDto,
-  ) {
+  ): Promise<boolean> {
+    if (this.isStartingGame(dto.userId)) return false;
+
     const waitingUserIdx = this.waitingQueue.findIndex(
       (item) => item.id !== dto.userId,
     );
@@ -356,6 +381,8 @@ export class GameGateway {
       };
       void this.startGame(player1, player2, 'random');
     }
+
+    return true;
   }
 
   async startGame(player1: Player, player2: Player, gameType: string) {

--- a/frontend/components/chat/friend/FriendListItem.tsx
+++ b/frontend/components/chat/friend/FriendListItem.tsx
@@ -90,7 +90,7 @@ export const FriendListItem = memo(function FriendListItem({
         updateInvitedFriendState({ friendId: friend.id });
         void router.push('game/home');
       } else {
-        setError('You have already sent invitation now!');
+        setError('You already started to play/prepare game');
       }
     });
   };

--- a/frontend/components/common/GameGuest.tsx
+++ b/frontend/components/common/GameGuest.tsx
@@ -1,9 +1,12 @@
 import {
+  Alert,
   Button,
   ButtonGroup,
+  Collapse,
   Dialog,
   DialogActions,
   DialogTitle,
+  IconButton,
   List,
   ListItem,
   ListItemText,
@@ -25,6 +28,7 @@ import { useQueryUser } from 'hooks/useQueryUser';
 import { Invitation } from 'types/game';
 import { CloseButton } from '@mantine/core';
 import { useMutationStatus } from 'hooks/useMutationStatus';
+import CloseIcon from '@mui/icons-material/Close';
 
 type Props = {
   hosts: Friend[];
@@ -34,6 +38,7 @@ type Props = {
 export const GameGuest = ({ hosts, setHosts }: Props) => {
   const [openDialog, setOpenDialog] = useState(false);
   const [openSnackbar, setOpenSnackbar] = useState(true);
+  const [openDialogError, setOpenDialogError] = useState(false);
   const { socket } = useSocketStore();
   const updatePlayState = usePlayStateStore((store) => store.updatePlayState);
   const updatePlayerNames = usePlayerNamesStore(
@@ -58,7 +63,9 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
           guestId: user.id,
           hostId: friend.id,
         };
-        socket.emit('acceptInvitation', match);
+        socket.emit('acceptInvitation', match, (res: boolean) => {
+          if (!res) setOpenDialogError(true);
+        });
       }
     },
     [user],
@@ -136,6 +143,26 @@ export const GameGuest = ({ hosts, setHosts }: Props) => {
       />
       <Dialog open={openDialog}>
         <DialogTitle>Friend Match</DialogTitle>
+        <Collapse in={openDialogError}>
+          <Alert
+            severity="error"
+            action={
+              <IconButton
+                aria-label="close"
+                color="inherit"
+                size="small"
+                onClick={() => {
+                  setOpenDialogError(false);
+                }}
+              >
+                <CloseIcon fontSize="inherit" />
+              </IconButton>
+            }
+            sx={{ mb: 2 }}
+          >
+            You already started to play/prepare game
+          </Alert>
+        </Collapse>
         <List>
           {hosts.map((host) => (
             <ListItem key={host.id}>

--- a/frontend/components/game/home/Display.tsx
+++ b/frontend/components/game/home/Display.tsx
@@ -1,5 +1,5 @@
 import { Grid, Paper } from '@mui/material';
-import { useEffect } from 'react';
+import { useEffect, useState } from 'react';
 import { usePlayStateStore, PlayState } from 'store/game/PlayState';
 import { Start } from './Start';
 import { Wait } from './Wait';
@@ -18,6 +18,7 @@ export const Display = () => {
   const updatePlayState = usePlayStateStore((store) => store.updatePlayState);
   const { invitedFriendState } = useInvitedFriendStateStore();
   const { updateStatusMutation } = useMutationStatus();
+  const [openMatchError, setOpenMatchError] = useState(false);
 
   useEffect(() => {
     if (user === undefined) {
@@ -61,9 +62,13 @@ export const Display = () => {
         </Grid>
         <Grid item xs={5} sx={{ minWidth: '430px' }}>
           <Paper elevation={2} sx={{ height: '100%' }}>
-            {playState === PlayState.stateNothing && <Start />}
+            {playState === PlayState.stateNothing && (
+              <Start setOpenMatchError={setOpenMatchError} />
+            )}
             {(playState === PlayState.stateWaiting ||
-              playState === PlayState.statePlaying) && <Wait />}
+              playState === PlayState.statePlaying) && (
+              <Wait openMatchError={openMatchError} />
+            )}
           </Paper>
         </Grid>
         <Grid item xs={5} sx={{ height: '60%', minWidth: '430px' }}>

--- a/frontend/components/game/home/Host.tsx
+++ b/frontend/components/game/home/Host.tsx
@@ -128,11 +128,11 @@ export const Host = () => {
               align="center"
               gutterBottom
             >
-              {invitationDenied && 'Invitation was denied...'}
-              {playState !== PlayState.stateNothing && 'Wait a Minute...'}
+              {invitationDenied && 'Invitation was denie'}
+              {playState !== PlayState.stateNothing && 'Wait a Minute'}
               {playState === PlayState.stateNothing &&
                 !invitationDenied &&
-                'Waiting for Opponent...'}
+                'Waiting for Opponent'}
             </Typography>
           </Grid>
         </>

--- a/frontend/components/game/home/Host.tsx
+++ b/frontend/components/game/home/Host.tsx
@@ -128,7 +128,7 @@ export const Host = () => {
               align="center"
               gutterBottom
             >
-              {invitationDenied && 'Invitation was denie'}
+              {invitationDenied && 'Invitation was denied'}
               {playState !== PlayState.stateNothing && 'Wait a Minute'}
               {playState === PlayState.stateNothing &&
                 !invitationDenied &&

--- a/frontend/components/game/home/Start.tsx
+++ b/frontend/components/game/home/Start.tsx
@@ -4,18 +4,26 @@ import { usePlayStateStore, PlayState } from 'store/game/PlayState';
 import { useSocketStore } from 'store/game/ClientSocket';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
+import { Dispatch, SetStateAction, useCallback } from 'react';
 
-export const Start = () => {
+type Props = {
+  setOpenMatchError: Dispatch<SetStateAction<boolean>>;
+};
+
+export const Start = ({ setOpenMatchError }: Props) => {
   const { socket } = useSocketStore();
   const updatePlayState = usePlayStateStore((store) => store.updatePlayState);
   const { data: user } = useQueryUser();
 
   if (user === undefined) return <Loading />;
 
-  const start = () => {
-    socket.emit('playStart', { userId: user.id });
+  const start = useCallback(() => {
+    setOpenMatchError(false);
     updatePlayState(PlayState.stateWaiting);
-  };
+    socket.emit('playStart', { userId: user.id }, (res: boolean) => {
+      if (!res) setOpenMatchError(true);
+    });
+  }, []);
 
   return (
     <>

--- a/frontend/components/game/home/Wait.tsx
+++ b/frontend/components/game/home/Wait.tsx
@@ -13,8 +13,13 @@ import { useRouter } from 'next/router';
 import DoneOutlineIcon from '@mui/icons-material/DoneOutline';
 import { useMutationStatus } from 'hooks/useMutationStatus';
 import { useQueryUser } from 'hooks/useQueryUser';
+import ErrorIcon from '@mui/icons-material/Error';
 
-export const Wait = () => {
+type Props = {
+  openMatchError: boolean;
+};
+
+export const Wait = ({ openMatchError }: Props) => {
   const updatePlayState = usePlayStateStore((store) => store.updatePlayState);
   const { playState } = usePlayStateStore();
   const [open, setOpen] = useState(true);
@@ -94,11 +99,13 @@ export const Wait = () => {
           }}
         >
           <Grid item>
-            {playState === PlayState.stateWaiting ? (
+            {playState === PlayState.stateWaiting && !openMatchError && (
               <CircularProgress />
-            ) : (
-              <DoneOutlineIcon />
             )}
+            {playState === PlayState.stateWaiting && openMatchError && (
+              <ErrorIcon fontSize="large" />
+            )}
+            {playState !== PlayState.stateWaiting && <DoneOutlineIcon />}
           </Grid>
           <Grid item sx={{ mt: 2 }}>
             <Typography
@@ -107,9 +114,13 @@ export const Wait = () => {
               align="center"
               gutterBottom
             >
-              {playState === PlayState.stateWaiting
-                ? 'Waiting for Opponent...'
-                : 'Wait a Minute...'}
+              {playState === PlayState.stateWaiting &&
+                !openMatchError &&
+                'Waiting for Opponent'}
+              {playState === PlayState.stateWaiting &&
+                openMatchError &&
+                'You already started to play/prepare game'}
+              {playState !== PlayState.stateWaiting && 'Wait a Minute'}
             </Typography>
           </Grid>
           {playState === PlayState.stateWaiting && (


### PR DESCRIPTION
# 概要

ボタンを押すと即座にまたは相手次第で自動でゲームが開始される場合
* RandomGameの「Play」
* FriendGameの「Invite Game」
* FriendGameの「Join」

を押した場合、
* ゲーム中
* 招待中
* マッチング待機中

かどうかを確認しひとつでも当てはまればエラーを返すようにしました。

# 動作確認

一通りは動画で表示させてあります。

同一のユーザでログインし、

ゲーム招待中に
* RandomGameの「Play」
* FriendGameの「Join」
(FriendGameの「Invite Game」はもともとできません。)

https://user-images.githubusercontent.com/64348608/213871185-9a78e1b4-1ca4-4c31-84e7-2e614f1feadf.mp4




マッチング待機中に
* RandomGameの「Play」
* FriendGameの「Invite Game」
* FriendGameの「Join」

https://user-images.githubusercontent.com/64348608/213871377-8cab3e8b-d5e3-4801-8081-53e963cda382.mp4

ゲーム中に
* RandomGameの「Play」
* FriendGameの「Invite Game」
* FriendGameの「Join」

https://user-images.githubusercontent.com/64348608/213870462-2d15dde1-0aa9-4a93-af95-d77c6eba2902.mp4

を押したときにエラーが出ることを確認する。

* resolve #298 

例えばエラーを出すのではなくボタンをdisableしたほうがいい気もしてますが、現状が一番簡単にできるのでこれでおおまかな仕様自体は完成としたいです(バグがなければ)。