### PR TITLE
Banされたユーザーに通知を送るようにした

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -508,9 +508,15 @@ export class ChatGateway {
     @MessageBody() dto: updateMemberStatusDto,
   ): Promise<boolean> {
     this.logger.log(`chat:banUser received -> roomId: ${dto.chatroomId}`);
-    const res = await this.chatService.updateMemberStatus(dto);
+    const updatedMemberStatus = await this.chatService.updateMemberStatus(dto);
 
-    return res ? true : false;
+    if (updatedMemberStatus) {
+      this.server
+        .to(this.generateSocketUserRoomName(dto.userId))
+        .emit('chat:banned');
+    }
+
+    return updatedMemberStatus ? true : false;
   }
 
   /**


### PR DESCRIPTION
## 概要
- **before**
  - ユーザーがBANされても、そのルームに入室しているとリロードするまでは入室中のままだった
  - メッセージは送信できないが、他のユーザーのやり取りを見ることができてしまっていた
- **after**
  - ユーザーがBANされたときに、通知を送ることで即座に反映させるようにした

## その他

~- https://github.com/ryo-manba/ft_transcendence/pull/309 からブランチ切ってしまったのでマージ待ち~

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/316

## demo

https://user-images.githubusercontent.com/76232929/213868466-7aee1ecf-aff6-42bc-8606-ef6e7ecb85dd.mov

注）動画ではアラートが自動で非表示になっていますが、これは別PRで出します。

