### PR TITLE
チャットのアラートを一定時間で非表示にする

### DIFF
--- a/frontend/components/chat/alert/ChatAlert.tsx
+++ b/frontend/components/chat/alert/ChatAlert.tsx
@@ -27,7 +27,7 @@ export const ChatAlert = memo(function ChatAlert({
     return () => {
       clearTimeout(timeId);
     };
-  }, [message, setMessage]);
+  }, [displayingTime, setMessage]);
 
   return (
     <Alert

--- a/frontend/components/chat/alert/ChatAlert.tsx
+++ b/frontend/components/chat/alert/ChatAlert.tsx
@@ -27,7 +27,8 @@ export const ChatAlert = memo(function ChatAlert({
     return () => {
       clearTimeout(timeId);
     };
-  }, [displayingTime, setMessage]);
+    // NOTE: 依存配列にmessageを追加しないとアラートが呼ばれるたびにtimeoutが実行されない
+  }, [message, displayingTime, setMessage]);
 
   return (
     <Alert

--- a/frontend/components/chat/alert/ChatAlert.tsx
+++ b/frontend/components/chat/alert/ChatAlert.tsx
@@ -1,38 +1,44 @@
 import { memo, useEffect } from 'react';
-import { IconButton, Alert } from '@mui/material';
+import { IconButton, Alert, AlertColor } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
 type Props = {
-  error: string;
-  setError: (error: string) => void;
+  displayingTime?: number;
+  severity: AlertColor;
+  message: string;
+  setMessage: (message: string) => void;
 };
 
-export const ChatErrorAlert = memo(function ChatErrorAlert({
-  error,
-  setError,
+// 指定がない場合は以下の秒数(ミリ秒)でアラートを非表示にする
+const DEFAULT_DISPLAYING_TIME = 3000;
+
+export const ChatAlert = memo(function ChatAlert({
+  displayingTime = DEFAULT_DISPLAYING_TIME,
+  severity,
+  message,
+  setMessage,
 }: Props) {
   useEffect(() => {
     // 一定時間経過したらアラートを非表示にする
-    const displayingAlertTime = 3000;
     const timeId = setTimeout(() => {
-      setError('');
-    }, displayingAlertTime);
+      setMessage('');
+    }, displayingTime);
 
     return () => {
       clearTimeout(timeId);
     };
-  }, [error, setError]);
+  }, [message, setMessage]);
 
   return (
     <Alert
-      severity="error"
+      severity={severity}
       action={
         <IconButton
           aria-label="close"
           color="inherit"
           size="small"
           onClick={() => {
-            setError('');
+            setMessage('');
           }}
         >
           <CloseIcon fontSize="inherit" />
@@ -40,7 +46,7 @@ export const ChatErrorAlert = memo(function ChatErrorAlert({
       }
       sx={{ mb: 2 }}
     >
-      {error}
+      {message}
     </Alert>
   );
 });

--- a/frontend/components/chat/alert/ChatAlertCollapse.tsx
+++ b/frontend/components/chat/alert/ChatAlertCollapse.tsx
@@ -1,0 +1,18 @@
+import { ReactNode, memo } from 'react';
+import { Box, Collapse } from '@mui/material';
+
+type Props = {
+  show: boolean;
+  children: ReactNode;
+};
+
+export const ChatAlertCollapse = memo(function ChatAlertCollapse({
+  show,
+  children,
+}: Props) {
+  return (
+    <Box sx={{ width: '100%' }}>
+      <Collapse in={show}>{children}</Collapse>
+    </Box>
+  );
+});

--- a/frontend/components/chat/alert/ChatErrorAlert.tsx
+++ b/frontend/components/chat/alert/ChatErrorAlert.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+import { ChatAlert } from 'components/chat/alert/ChatAlert';
+
+type Props = {
+  error: string;
+  setError: (error: string) => void;
+};
+
+export const ChatErrorAlert = memo(function ChatErrorAlert({
+  error,
+  setError,
+}: Props) {
+  return <ChatAlert severity="error" message={error} setMessage={setError} />;
+});

--- a/frontend/components/chat/alert/ChatSuccessAlert.tsx
+++ b/frontend/components/chat/alert/ChatSuccessAlert.tsx
@@ -1,0 +1,16 @@
+import { memo } from 'react';
+import { ChatAlert } from 'components/chat/alert/ChatAlert';
+
+type Props = {
+  success: string;
+  setSuccess: (success: string) => void;
+};
+
+export const ChatSuccessAlert = memo(function ChatSuccessAlert({
+  success,
+  setSuccess,
+}: Props) {
+  return (
+    <ChatAlert severity="success" message={success} setMessage={setSuccess} />
+  );
+});

--- a/frontend/components/chat/block/ChatBlockDialog.tsx
+++ b/frontend/components/chat/block/ChatBlockDialog.tsx
@@ -1,13 +1,11 @@
 import { memo, useState, useEffect } from 'react';
 import { Socket } from 'socket.io-client';
 import {
-  Box,
   Button,
   Dialog,
   DialogActions,
   DialogTitle,
   DialogContent,
-  Collapse,
   Select,
   SelectChangeEvent,
   MenuItem,
@@ -16,12 +14,13 @@ import {
 } from '@mui/material';
 import { blue } from '@mui/material/colors';
 import { ChatUser, ChatBlockSetting } from 'types/chat';
-import { useQueryUser } from 'hooks/useQueryUser';
-import { Loading } from 'components/common/Loading';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
-import { ChatBlockSettingDetailDialog } from 'components/chat/block/ChatBlockSettingDetailDialog';
 import { fetchBlockedUsers } from 'api/chat/fetchBlockedUsers';
 import { fetchUnblockedUsers } from 'api/chat/fetchUnblockedUsers';
+import { useQueryUser } from 'hooks/useQueryUser';
+import { Loading } from 'components/common/Loading';
+import { ChatBlockSettingDetailDialog } from 'components/chat/block/ChatBlockSettingDetailDialog';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 type Props = {
   socket: Socket;
@@ -203,11 +202,9 @@ export const ChatBlockDialog = memo(function ChatBlockDialog({
           onChange={handleChangeUserId}
         />
       )}
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={error !== ''}>
-          <ChatErrorAlert error={error} setError={setError} />
-        </Collapse>
-      </Box>
+      <ChatAlertCollapse show={error !== ''}>
+        <ChatErrorAlert error={error} setError={setError} />
+      </ChatAlertCollapse>
       <DialogActions>
         <Button onClick={handleClose} variant="outlined">
           Cancel

--- a/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
+++ b/frontend/components/chat/chatroom/ChatroomCreateButton.tsx
@@ -3,10 +3,9 @@ import { Socket } from 'socket.io-client';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
+import Debug from 'debug';
 import {
   Button,
-  Box,
-  Collapse,
   TextField,
   Dialog,
   DialogActions,
@@ -22,9 +21,9 @@ import AddCircleOutlineRounded from '@mui/icons-material/AddCircleOutlineRounded
 import { CreateChatroomInfo, ChatroomType, Chatroom } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 import { ChatPasswordForm } from 'components/chat/utils/ChatPasswordForm';
-import Debug from 'debug';
 
 type Props = {
   socket: Socket;
@@ -119,11 +118,9 @@ export const ChatroomCreateButton = memo(function ChatroomCreateButton({
 
   return (
     <>
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={error !== ''}>
-          <ChatErrorAlert error={error} setError={setError} />
-        </Collapse>
-      </Box>
+      <ChatAlertCollapse show={error !== ''}>
+        <ChatErrorAlert error={error} setError={setError} />
+      </ChatAlertCollapse>
       <Button
         color="primary"
         variant="outlined"

--- a/frontend/components/chat/chatroom/ChatroomJoinDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomJoinDialog.tsx
@@ -1,5 +1,6 @@
 import { memo, useState } from 'react';
 import { useForm, SubmitHandler, Controller } from 'react-hook-form';
+import { Socket } from 'socket.io-client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import * as z from 'zod';
 import {
@@ -16,7 +17,6 @@ import {
   DialogContent,
   InputAdornment,
   IconButton,
-  Collapse,
   TextField,
 } from '@mui/material';
 import { blue } from '@mui/material/colors';
@@ -24,11 +24,11 @@ import ChatIcon from '@mui/icons-material/Chat';
 import LockIcon from '@mui/icons-material/Lock';
 import Visibility from '@mui/icons-material/Visibility';
 import VisibilityOffIcon from '@mui/icons-material/VisibilityOff';
-import { Socket } from 'socket.io-client';
 import { Chatroom, ChatroomType, JoinChatroomInfo } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 type Props = {
   open: boolean;
@@ -157,11 +157,9 @@ export const ChatroomJoinDialog = memo(function ChatroomJoinDialog({
           )}
           {isProtected(selectedRoom) && (
             <>
-              <Box sx={{ width: '100%' }}>
-                <Collapse in={error !== ''}>
-                  <ChatErrorAlert error={error} setError={setError} />
-                </Collapse>
-              </Box>
+              <ChatAlertCollapse show={error !== ''}>
+                <ChatErrorAlert error={error} setError={setError} />
+              </ChatAlertCollapse>
               <Controller
                 name="password"
                 control={control}

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -1,25 +1,23 @@
 import { memo, useState, useEffect, Dispatch, SetStateAction } from 'react';
+import { Socket } from 'socket.io-client';
+import Debug from 'debug';
 import {
   ListItem,
   IconButton,
   ListItemText,
   ListItemAvatar,
   Avatar,
-  Alert,
-  Box,
-  Collapse,
 } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ChatIcon from '@mui/icons-material/Chat';
-import CloseIcon from '@mui/icons-material/Close';
 import { ChatroomMembersStatus, ChatroomType } from '@prisma/client';
-import { Socket } from 'socket.io-client';
 import { Chatroom, Message, JoinChatroomInfo, CurrentRoom } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
 import { ChatroomSettingDialog } from 'components/chat/chatroom/ChatroomSettingDialog';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
-import Debug from 'debug';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatSuccessAlert } from 'components/chat/alert/ChatSuccessAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 type Props = {
   room: Chatroom;
@@ -278,36 +276,15 @@ export const ChatroomListItem = memo(function ChatroomListItem({
 
   return (
     <>
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={error !== ''}>
-          <ChatErrorAlert
-            error={`${room.name}: ${error}`}
-            setError={setError}
-          />
-        </Collapse>
-      </Box>
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={success !== ''}>
-          <Alert
-            severity="success"
-            action={
-              <IconButton
-                aria-label="close"
-                color="inherit"
-                size="small"
-                onClick={() => {
-                  setSuccess('');
-                }}
-              >
-                <CloseIcon fontSize="inherit" />
-              </IconButton>
-            }
-            sx={{ mb: 2 }}
-          >
-            {`${room.name}: ${success}`}
-          </Alert>
-        </Collapse>
-      </Box>
+      <ChatAlertCollapse show={error !== ''}>
+        <ChatErrorAlert error={`${room.name}: ${error}`} setError={setError} />
+      </ChatAlertCollapse>
+      <ChatAlertCollapse show={success !== ''}>
+        <ChatSuccessAlert
+          success={`${room.name}: ${success}`}
+          setSuccess={setSuccess}
+        />
+      </ChatAlertCollapse>
       <ListItem
         secondaryAction={
           <IconButton

--- a/frontend/components/chat/friend/FriendAddDialog.tsx
+++ b/frontend/components/chat/friend/FriendAddDialog.tsx
@@ -3,7 +3,6 @@ import {
   Avatar,
   Box,
   Button,
-  Collapse,
   List,
   ListItem,
   ListItemAvatar,
@@ -14,12 +13,13 @@ import {
   DialogContent,
 } from '@mui/material';
 import { blue } from '@mui/material/colors';
-import { useQueryUser } from 'hooks/useQueryUser';
-import { Loading } from 'components/common/Loading';
-import { followUser } from 'api/friend/followUser';
 import type { Friend } from 'types/friend';
+import { followUser } from 'api/friend/followUser';
+import { useQueryUser } from 'hooks/useQueryUser';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
+import { Loading } from 'components/common/Loading';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 type Props = {
   open: boolean;
@@ -118,11 +118,9 @@ export const FriendAddDialog = memo(function FriendAddDialog({
       {selectedUser && (
         <p className="text-center">Selected: {selectedUser.name}</p>
       )}
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={error !== ''}>
-          <ChatErrorAlert error={error} setError={setError} />
-        </Collapse>
-      </Box>
+      <ChatAlertCollapse show={error !== ''}>
+        <ChatErrorAlert error={error} setError={setError} />
+      </ChatAlertCollapse>
       <DialogActions>
         <Button onClick={handleClose}>Cancel</Button>
         <Button

--- a/frontend/components/chat/friend/FriendListItem.tsx
+++ b/frontend/components/chat/friend/FriendListItem.tsx
@@ -1,27 +1,22 @@
 import { useState, memo, useEffect, Dispatch, SetStateAction } from 'react';
-import {
-  ListItem,
-  ListItemText,
-  ListItemAvatar,
-  Box,
-  Collapse,
-} from '@mui/material';
+import { useRouter } from 'next/router';
+import Debug from 'debug';
 import { Socket } from 'socket.io-client';
+import { ListItem, ListItemText, ListItemAvatar } from '@mui/material';
+import { UserStatus } from '@prisma/client';
 import { Friend } from 'types/friend';
+import { Invitation } from 'types/game';
+import { CurrentRoom } from 'types/chat';
+import { useSocketStore } from 'store/game/ClientSocket';
+import { useInvitedFriendStateStore } from 'store/game/InvitedFriendState';
+import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
+import { getUserStatusById } from 'api/user/getUserStatusById';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { FriendInfoDialog } from 'components/chat/friend/FriendInfoDialog';
 import { Loading } from 'components/common/Loading';
-import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
-import { getUserStatusById } from 'api/user/getUserStatusById';
-import { UserStatus } from '@prisma/client';
-import { useSocketStore } from 'store/game/ClientSocket';
-import { useInvitedFriendStateStore } from 'store/game/InvitedFriendState';
-import { useRouter } from 'next/router';
-import { Invitation } from 'types/game';
 import { BadgedAvatar } from 'components/common/BadgedAvatar';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
-import Debug from 'debug';
-import { CurrentRoom } from 'types/chat';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 type Props = {
   friend: Friend;
@@ -127,11 +122,9 @@ export const FriendListItem = memo(function FriendListItem({
 
   return (
     <>
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={error !== ''}>
-          <ChatErrorAlert error={error} setError={setError} />
-        </Collapse>
-      </Box>
+      <ChatAlertCollapse show={error !== ''}>
+        <ChatErrorAlert error={error} setError={setError} />
+      </ChatAlertCollapse>
       <ListItem divider button onClick={handleClickOpen}>
         <ListItemAvatar>
           <BadgedAvatar

--- a/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
@@ -1,14 +1,15 @@
 import { memo, useState, useEffect, Dispatch, SetStateAction } from 'react';
 import Debug from 'debug';
 import { Socket } from 'socket.io-client';
-import { Box, Collapse, Paper } from '@mui/material';
+import { Paper } from '@mui/material';
 import { Message, CurrentRoom } from 'types/chat';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { Loading } from 'components/common/Loading';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
 import { ChatTextInput } from 'components/chat/message-exchange/ChatTextInput';
 import { ChatMessageList } from 'components/chat/message-exchange/ChatMessageList';
 import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 type Props = {
   socket: Socket;
@@ -92,11 +93,9 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
             socket={socket}
           />
         </div>
-        <Box sx={{ width: '100%' }}>
-          <Collapse in={error !== ''}>
-            <ChatErrorAlert error={error} setError={setError} />
-          </Collapse>
-        </Box>
+        <ChatAlertCollapse show={error !== ''}>
+          <ChatErrorAlert error={error} setError={setError} />
+        </ChatAlertCollapse>
         <form style={{ display: 'flex', alignItems: 'center', padding: '2px' }}>
           <ChatTextInput
             roomName={currentRoom.name}

--- a/frontend/components/chat/utils/ChatErrorAlert.tsx
+++ b/frontend/components/chat/utils/ChatErrorAlert.tsx
@@ -1,4 +1,4 @@
-import { memo } from 'react';
+import { memo, useEffect } from 'react';
 import { IconButton, Alert } from '@mui/material';
 import CloseIcon from '@mui/icons-material/Close';
 
@@ -11,6 +11,18 @@ export const ChatErrorAlert = memo(function ChatErrorAlert({
   error,
   setError,
 }: Props) {
+  useEffect(() => {
+    // 一定時間経過したらアラートを非表示にする
+    const displayingAlertTime = 3000;
+    const timeId = setTimeout(() => {
+      setError('');
+    }, displayingAlertTime);
+
+    return () => {
+      clearTimeout(timeId);
+    };
+  }, [error, setError]);
+
   return (
     <Alert
       severity="error"

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -2,7 +2,6 @@ import { NextPage } from 'next';
 import { useState, useEffect } from 'react';
 import { io, Socket } from 'socket.io-client';
 import Grid from '@mui/material/Unstable_Grid2';
-import { Box, Collapse } from '@mui/material';
 import { Message, CurrentRoom } from 'types/chat';
 import { Header } from 'components/common/Header';
 import { ChatroomSidebar } from 'components/chat/chatroom/ChatroomSidebar';
@@ -12,7 +11,8 @@ import { ChatMessageExchange } from 'components/chat/message-exchange/ChatMessag
 import { Loading } from 'components/common/Loading';
 import { useQueryUser } from 'hooks/useQueryUser';
 import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
-import { ChatErrorAlert } from 'components/chat/utils/ChatErrorAlert';
+import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
+import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 
 const Chat: NextPage = () => {
   const [socket, setSocket] = useState<Socket>();
@@ -61,11 +61,9 @@ const Chat: NextPage = () => {
   return (
     <Layout title="Chat">
       <Header title="Chatroom" />
-      <Box sx={{ width: '100%' }}>
-        <Collapse in={error !== ''}>
-          <ChatErrorAlert error={error} setError={setError} />
-        </Collapse>
-      </Box>
+      <ChatAlertCollapse show={error !== ''}>
+        <ChatErrorAlert error={error} setError={setError} />
+      </ChatAlertCollapse>
       <Grid
         container
         direction="row"


### PR DESCRIPTION
## 概要
- **before**
  - アラート表示がバツボタンを押すまでずっと表示されている
- **after**
  - 3秒経過したら自動で非表示にする（時間は変更可能）

### その他

- タイムアウトの仕組みは以下の記事を参考にしました
  - https://stackoverflow.com/questions/65214950/how-to-disappear-alert-after-5-seconds-in-react-js
- Alertのラッパー関数を作成し処理をまとめました

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/325

## demo
https://user-images.githubusercontent.com/76232929/213870919-08f102b0-bb95-49ba-a837-50d70fc67a61.mov
