### PR TITLE
チャットルーム退出時にadminの設定を解除する

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -15,6 +15,7 @@ import { DeleteChatroomDto } from './dto/delete-chatroom.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { CreateAdminDto } from './dto/create-admin.dto';
+import { DeleteAdminDto } from './dto/delete-admin.dto';
 import { updatePasswordDto } from './dto/update-password.dto';
 import { updateMemberStatusDto } from './dto/update-member-status.dto';
 import { CreateDirectMessageDto } from './dto/create-direct-message.dto';
@@ -363,6 +364,14 @@ export class ChatGateway {
     await this.leaveSocket(client, {
       roomId: dto.chatroomId,
     });
+
+    // TODO: adminの判定をする
+    // adminの設定を削除する
+    const deleteAdminDto: DeleteAdminDto = {
+      userId: dto.userId,
+      chatroomId: dto.chatroomId,
+    };
+    await this.chatService.deleteAdmin(deleteAdminDto);
 
     // チャットルームを抜けたことで入室者がいなくなる場合は削除する
     // BAN or MUTEのユーザーは無視する

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -14,6 +14,7 @@ import {
 import { CreateChatroomDto } from './dto/create-chatroom.dto';
 import { CreateMessageDto } from './dto/create-message.dto';
 import { CreateAdminDto } from './dto/create-admin.dto';
+import { DeleteAdminDto } from './dto/delete-admin.dto';
 import { JoinChatroomDto } from './dto/join-chatroom.dto';
 import type { ChatUser, ChatMessage } from './types/chat';
 import { updatePasswordDto } from './dto/update-password.dto';
@@ -550,6 +551,28 @@ export class ChatService {
       return admin;
     } catch (error) {
       this.logger.log('createAdmin', error);
+
+      return undefined;
+    }
+  }
+
+  /**
+   * チャットルームのadminを削除する
+   * @param CreateAdminDto
+   */
+  async deleteAdmin(dto: DeleteAdminDto): Promise<ChatroomAdmin> {
+    try {
+      const deletedAdmin = await this.prisma.chatroomAdmin.delete({
+        where: {
+          chatroomId_userId: {
+            ...dto,
+          },
+        },
+      });
+
+      return deletedAdmin;
+    } catch (error) {
+      this.logger.log('deleteAdmin', error);
 
       return undefined;
     }

--- a/backend/src/chat/dto/delete-admin.dto.ts
+++ b/backend/src/chat/dto/delete-admin.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class DeleteAdminDto {
+  @IsNumber()
+  @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+}


### PR DESCRIPTION
## 概要
- **before**
  - adminがチャットルームを退出して、再度入室すると再びadminになる
  - つまり、チャットルームかユーザー削除されるまでadminのままになっていた
- **after**
  - 退出時にadminの設定を解除するようにした

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/330

## demo

https://user-images.githubusercontent.com/76232929/213953236-aeaa62ec-3e72-4434-9076-8bcc2148e551.mov


