### PR TITLE
第三者がDMに入室できてしまうバグを修正した

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -436,17 +436,16 @@ export class ChatGateway {
   ): Promise<ClientChatroom[]> {
     this.logger.log(`chat:getJoinableRooms received -> roomId: ${dto.userId}`);
 
-    // Private以外のチャットルームに絞る
-    const notPrivate = {
-      where: {
-        type: {
-          notIn: <ChatroomType>'PRIVATE',
-        },
-      },
-    };
+    const notDisplayRoomType = [ChatroomType.PRIVATE, ChatroomType.DM];
 
     // public, protectedのチャットルーム一覧を取得する
-    const viewableRooms = await this.chatService.findAll(notPrivate);
+    const viewableRooms = await this.chatService.findAll({
+      where: {
+        NOT: {
+          type: { in: notDisplayRoomType },
+        },
+      },
+    });
 
     // userが所属しているチャットルームの一覧を取得する
     const joinedRooms = await this.chatService.findJoinedRooms(dto.userId);

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -436,13 +436,13 @@ export class ChatGateway {
   ): Promise<ClientChatroom[]> {
     this.logger.log(`chat:getJoinableRooms received -> roomId: ${dto.userId}`);
 
-    const notDisplayRoomType = [ChatroomType.PRIVATE, ChatroomType.DM];
+    const hiddenChatRooms = [ChatroomType.PRIVATE, ChatroomType.DM];
 
     // public, protectedのチャットルーム一覧を取得する
     const viewableRooms = await this.chatService.findAll({
       where: {
         NOT: {
-          type: { in: notDisplayRoomType },
+          type: { in: hiddenChatRooms },
         },
       },
     });


### PR DESCRIPTION
## 概要

- **before**
  - Searchボタンを押すと、DMのルームも表示されてしまっていた
- **after**
  - DMのルームは表示しないようにした

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/336

## demo

https://user-images.githubusercontent.com/76232929/214283068-faaaf751-48bf-4af3-97ec-ad202438b2c1.mov

