### PR TITLE
ゲーム開始時のボールの位置のバグを修正

### DIFF
--- a/frontend/components/game/battle/Play.tsx
+++ b/frontend/components/game/battle/Play.tsx
@@ -65,7 +65,7 @@ const getGameParameters = (
     sideBarRight: convert2Int(canvasWidth * 0.95 + topLeftX),
     lineDashStyle: [20, 5],
     initialHeight: 0,
-    ballInitialX: convert2Int(canvasWidth / 2 + topLeftX),
+    ballInitialX: convert2Int(canvasWidth / 2),
     ballInitialY: 0,
     ballRadius: convert2Int(canvasWidth * 0.01),
     widthRatio: 0,


### PR DESCRIPTION
## 概要

### Before

ゲームのボードの幅がウィンドウの幅より小さい場合に、ボールの開始位置が右にずれてしまっていた

### After

どのような場合でもボールの開始位置が正しい位置に修正された

## 関連イシュー

- resolve #327 