### PR TITLE
チャット画面のアバターをアップロードしたアバターに変更

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -207,6 +207,7 @@ export class ChatGateway {
     const chatMessage: ChatMessage = {
       roomId: message.chatroomId,
       text: message.message,
+      userId: createMessageDto.userId,
       userName: createMessageDto.userName,
       createdAt: message.createdAt,
     };

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -212,6 +212,7 @@ export class ChatService {
       return {
         roomId: message.chatroomId,
         text: message.message,
+        userId: message.userId,
         userName: message.user.name,
         createdAt: message.createdAt,
       };

--- a/backend/src/chat/types/chat.ts
+++ b/backend/src/chat/types/chat.ts
@@ -6,6 +6,7 @@ export type ChatUser = {
 export type ChatMessage = {
   roomId: number;
   text: string;
+  userId: number;
   userName: string;
   createdAt: Date;
 };

--- a/frontend/components/chat/message-exchange/ChatMessage.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessage.tsx
@@ -1,9 +1,11 @@
 import { Avatar } from '@mui/material';
+import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
 
 type Props = {
   message: string;
   timestamp: Date;
   displayName: string;
+  userId: number;
 };
 
 /**
@@ -22,48 +24,21 @@ const truncateDate = (date: Date): string => {
   return res;
 };
 
-/**
- * DOCS: https://mui.com/material-ui/react-avatar/#letter-avatars
- * 名前によって背景色を変更する
- */
-const stringToColor = (string: string) => {
-  let hash = 0;
-  let i;
-
-  for (i = 0; i < string.length; i += 1) {
-    hash = string.charCodeAt(i) + ((hash << 5) - hash);
-  }
-
-  let color = '#';
-
-  for (i = 0; i < 3; i += 1) {
-    const value = (hash >> (i * 8)) & 0xff;
-    color += `00${value.toString(16)}`.slice(-2);
-  }
-
-  return color;
-};
-
-const stringAvatar = (name: string) => {
-  return {
-    sx: {
-      bgcolor: stringToColor(name),
-    },
-    children: name[0],
-  };
-};
-
-export const MessageLeft = ({ message, timestamp, displayName }: Props) => {
+export const MessageLeft = ({
+  message,
+  timestamp,
+  displayName,
+  userId,
+}: Props) => {
   // 時間を表示用に変換する
   const displayTimestamp = truncateDate(new Date(timestamp));
+
+  const avatarImageUrl = getAvatarImageUrl(userId);
 
   return (
     <>
       <div style={{ display: 'flex', margin: '10px' }}>
-        <Avatar
-          // eslint-disable-next-line react/jsx-props-no-spreading
-          {...stringAvatar(displayName)}
-        />
+        <Avatar src={avatarImageUrl} />
         <div>
           <div
             style={{

--- a/frontend/components/chat/message-exchange/ChatMessage.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessage.tsx
@@ -1,5 +1,6 @@
 import { Avatar } from '@mui/material';
 import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
+import { useState } from 'react';
 
 type Props = {
   message: string;
@@ -24,6 +25,42 @@ const truncateDate = (date: Date): string => {
   return res;
 };
 
+/**
+ * DOCS: https://mui.com/material-ui/react-avatar/#letter-avatars
+ * 名前によって背景色を変更する
+ */
+const stringToColor = (string: string, isLoadingError: boolean) => {
+  let hash = 0;
+  let i;
+
+  for (i = 0; i < string.length; i += 1) {
+    hash = string.charCodeAt(i) + ((hash << 5) - hash);
+  }
+
+  let color = '#';
+
+  for (i = 0; i < 3; i += 1) {
+    const value = (hash >> (i * 8)) & 0xff;
+    color += `00${value.toString(16)}`.slice(-2);
+  }
+
+  return isLoadingError ? color : '';
+};
+
+/**
+ * イメージソースが読み込めない場合 (=Avatarがアップロードされていない場合)のみ
+ * bgcolorを変えるようにしないと、Avatarがある場合にもbgcolorが変わってしまう
+ * ため、isLoadingErrorを引数に追加
+ */
+const stringAvatar = (name: string, isLoadingError: boolean) => {
+  return {
+    sx: {
+      bgcolor: stringToColor(name, isLoadingError),
+    },
+    children: name[0],
+  };
+};
+
 export const MessageLeft = ({
   message,
   timestamp,
@@ -35,10 +72,23 @@ export const MessageLeft = ({
 
   const avatarImageUrl = getAvatarImageUrl(userId);
 
+  const [isLoadingError, setIsLoadingError] = useState(false);
+
+  const handleLoadingError = () => {
+    setIsLoadingError(true);
+  };
+
   return (
     <>
       <div style={{ display: 'flex', margin: '10px' }}>
-        <Avatar src={avatarImageUrl} />
+        <Avatar
+          // eslint-disable-next-line react/jsx-props-no-spreading
+          {...stringAvatar(displayName, isLoadingError)}
+          src={avatarImageUrl}
+          // imgPropsを使うと、エラーが起きたときに発火する関数を設定できる
+          // 参考: https://github.com/mui/material-ui/issues/11128
+          imgProps={{ onError: handleLoadingError }}
+        />
         <div>
           <div
             style={{

--- a/frontend/components/chat/message-exchange/ChatMessageList.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageList.tsx
@@ -106,6 +106,7 @@ export const ChatMessageList = memo(function ChatMessageList({
       message={item.text}
       timestamp={item.createdAt}
       displayName={item.userName}
+      userId={item.userId}
     />
   );
 

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -27,6 +27,7 @@ export type JoinChatroomInfo = {
 export type Message = {
   roomId: number;
   text: string;
+  userId: number;
   userName: string;
   createdAt: Date;
 };


### PR DESCRIPTION
## 概要

割と軽微な修正でできたので、チャットにアバターを表示させてみました。

### Before

チャット画面のアバターはユーザー名の最初の文字とそれに合わせた背景色になっていた

### After

Setting画面からuploadしたAvatar Imageをチャット画面にも表示させるようにした

## スクリーンショット

<img width="1680" alt="image" src="https://user-images.githubusercontent.com/15176241/215309724-1e072044-8e36-492b-9108-42e14789b41a.png">
