### PR TITLE
チャット画面をレスポンシブ対応した

### DIFF
--- a/frontend/components/chat/message-exchange/ChatMessage.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessage.tsx
@@ -44,7 +44,7 @@ export const MessageLeft = ({
           displayName={displayName}
           avatarFontSize={AvatarFontSize.SMALL}
         />
-        <div>
+        <div style={{ overflow: 'hidden', width: '100%' }}>
           <div
             style={{
               marginLeft: '20px',
@@ -54,7 +54,12 @@ export const MessageLeft = ({
           >
             {`${displayName} ${displayTimestamp}`}
           </div>
-          <div>
+          <div
+            style={{
+              overflowWrap: 'break-word',
+              wordWrap: 'break-word',
+            }}
+          >
             <p
               style={{
                 marginLeft: '20px',

--- a/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
@@ -119,16 +119,10 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
           flexDirection: 'column',
         }}
       >
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            overflow: 'auto',
-            marginBottom: '15px',
-            flexGrow: 1,
-          }}
-        >
-          <h3 className="my-2 ml-1 underline">#{roomName}</h3>
+        <div className="mb-4 flex grow-[1] flex-col">
+          <h3 className="my-2 ml-1 overflow-hidden text-ellipsis whitespace-nowrap underline">
+            #{currentRoom.name}
+          </h3>
           <ChatMessageList
             currentRoomId={currentRoom.id}
             messages={messages}

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -81,7 +81,8 @@ const Chat: NextPage = () => {
         style={heightStyle}
       >
         <Grid
-          xs={2}
+          xs={3}
+          md={2}
           style={{
             borderRight: '1px solid',
             borderBottom: '1px solid',
@@ -94,7 +95,8 @@ const Chat: NextPage = () => {
           />
         </Grid>
         <Grid
-          xs={8}
+          xs={6}
+          md={8}
           style={{
             borderRight: '1px solid',
             borderBottom: '1px solid',
@@ -110,7 +112,8 @@ const Chat: NextPage = () => {
           )}
         </Grid>
         <Grid
-          xs={2}
+          xs={3}
+          md={2}
           style={{
             borderBottom: '1px solid',
           }}


### PR DESCRIPTION
## 概要
- スマホ幅のスタイルを調整した。
- それに伴い長いメッセージは折り返すようにした。

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/373

## screen shot

### スマホ幅
<img width="923" alt="スクリーンショット 2023-02-02 17 41 35" src="https://user-images.githubusercontent.com/76232929/216277579-c7fa4f8d-9272-4e4f-82a8-20385c5ebcab.png">

### メッセージの折返し
<img width="1410" alt="スクリーンショット 2023-02-02 17 42 09" src="https://user-images.githubusercontent.com/76232929/216277776-9c4a3d24-2546-47d6-9c61-50da710ee270.png">

