### PR TITLE
GameのResultの画面でホームに戻るボタンが次の列にWrapされないようにした

### DIFF
--- a/frontend/components/game/battle/Result.tsx
+++ b/frontend/components/game/battle/Result.tsx
@@ -16,6 +16,7 @@ export const Result = ({ finishedGameInfo }: Props) => {
       justifyContent="center"
       alignItems="center"
       direction="column"
+      wrap="nowrap"
       sx={{
         position: 'absolute',
         top: '40%',
@@ -117,7 +118,6 @@ export const Result = ({ finishedGameInfo }: Props) => {
           </Grid>
         </Grid>
       )}
-      <br />
       <Grid item>
         <Link href="/game/home">
           <Button variant="contained">Back to Home</Button>


### PR DESCRIPTION
## 概要

### Before

GameのResultの画面でウィンドウの縦幅を短くすると、Go back to homeのボタンが、試合結果の表示の横に表示されてしまっていた。

### After

縦幅を短くしても、ボタンが常に試合結果の下に表示されるようにした。

## 関連イシュー

- resolve #378 