### PR TITLE
メニューアイコンをアバターに置き換えた

### DIFF
--- a/frontend/components/common/MenuButton.tsx
+++ b/frontend/components/common/MenuButton.tsx
@@ -1,5 +1,4 @@
 import { IconButton } from '@mui/material';
-import MenuIcon from '@mui/icons-material/Menu';
 import Menu from '@mui/material/Menu';
 import MenuItem from '@mui/material/MenuItem';
 import { useState } from 'react';
@@ -11,6 +10,9 @@ import { Loading } from './Loading';
 import { logout } from 'api/auth/logout';
 import { useRouter } from 'next/router';
 import { useSocketStore } from 'store/game/ClientSocket';
+import { BadgedAvatar } from 'components/common/BadgedAvatar';
+import { getAvatarImageUrl } from 'api/user/getAvatarImageUrl';
+import { AvatarFontSize } from 'types/utils';
 
 export const MenuButton = () => {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
@@ -38,7 +40,11 @@ export const MenuButton = () => {
         aria-expanded={open ? 'true' : undefined}
         onClick={handleClick}
       >
-        <MenuIcon />
+        <BadgedAvatar
+          src={getAvatarImageUrl(user.id)}
+          displayName={user.name}
+          avatarFontSize={AvatarFontSize.SMALL}
+        />
       </IconButton>
       <Menu
         id="basic-menu"


### PR DESCRIPTION
* Resolve #384 
# 変更点
右上のメニューボタンをアバターに変更した

# 確認したこと
ホーム、チャット、ゲーム、プロフィール、設定、などで、アバターが正しく表示されること
設定でアバターを変更した際、同時にメニューボタンの画像も更新されること