### PR TITLE
ブロックしたユーザーのメッセージを表示させない

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -199,11 +199,13 @@ export class ChatController {
   @Get('messages')
   async findChatMessages(
     @Query('roomId', ParseIntPipe) roomId: number,
+    @Query('userId', ParseIntPipe) userId: number,
     @Query('skip', ParseIntPipe) skip: number,
     @Query('pageSize', ParseIntPipe) pageSize: number,
   ): Promise<ChatMessage[]> {
     const chatMessages = await this.chatService.findChatMessages({
       chatroomId: roomId,
+      userId: userId,
       skip: skip,
       pageSize: pageSize,
     });

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -759,6 +759,9 @@ export class ChatGateway {
       this.server
         .to(this.generateSocketUserRoomName(dto.blockingUserId))
         .emit('chat:blocked', dto.blockedByUserId);
+
+      // ブロックしたユーザーのメッセージを非表示にするため通知する
+      client.emit('chat:blockUser', dto.blockingUserId);
     }
 
     return isSuccess;
@@ -775,7 +778,13 @@ export class ChatGateway {
   ): Promise<boolean> {
     this.logger.log('chat:unblockUser received', dto);
 
-    return await this.blockService.unblockUser(dto);
+    const isSuccess = await this.blockService.unblockUser(dto);
+    if (isSuccess) {
+      // ブロックを解除したユーザーのメッセージを非示するため通知する
+      client.emit('chat:unblockUser', dto.blockingUserId);
+    }
+
+    return isSuccess;
   }
 
   /**

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -42,6 +42,7 @@ export class ChatService {
       blockedByUserId: dto.userId,
     });
     const blockedUserIds = blockedUsers.map((user) => user.id);
+    this.logger.log('findChatMessages: blockedUserIds', blockedUserIds);
 
     const messages = await this.prisma.message.findMany({
       where: {
@@ -71,6 +72,8 @@ export class ChatService {
         createdAt: message.createdAt,
       };
     });
+
+    this.logger.log('chatMessages:', chatMessages);
 
     return chatMessages;
   }

--- a/backend/src/chat/chat.service.ts
+++ b/backend/src/chat/chat.service.ts
@@ -4,10 +4,14 @@ import { Message } from '@prisma/client';
 import type { ChatMessage } from './types/chat';
 import { CreateMessageDto } from './dto/message/create-message.dto';
 import { GetMessagesDto } from './dto//message/get-messages.dto';
+import { BlockService } from './block.service';
 
 @Injectable()
 export class ChatService {
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly blockService: BlockService,
+  ) {}
 
   private logger: Logger = new Logger('ChatService');
 
@@ -34,9 +38,17 @@ export class ChatService {
    * @param GetMessagesDto
    */
   async findChatMessages(dto: GetMessagesDto): Promise<ChatMessage[]> {
+    const blockedUsers = await this.blockService.findBlockedUsers({
+      blockedByUserId: dto.userId,
+    });
+    const blockedUserIds = blockedUsers.map((user) => user.id);
+
     const messages = await this.prisma.message.findMany({
       where: {
         chatroomId: dto.chatroomId,
+        userId: {
+          notIn: blockedUserIds,
+        },
       },
       skip: dto.pageSize * dto.skip,
       take: dto.pageSize,

--- a/backend/src/chat/dto/message/get-messages.dto.ts
+++ b/backend/src/chat/dto/message/get-messages.dto.ts
@@ -9,6 +9,10 @@ export class GetMessagesDto {
 
   @IsNumber()
   @IsNotEmpty()
+  userId: number;
+
+  @IsNumber()
+  @IsNotEmpty()
   skip: number;
 
   @IsNumber()

--- a/frontend/api/chat/fetchMessages.ts
+++ b/frontend/api/chat/fetchMessages.ts
@@ -4,17 +4,23 @@ import Debug from 'debug';
 
 type Props = {
   roomId: number;
+  userId: number;
   skip: number;
   pageSize?: number;
 };
 
 const endpoint = `${process.env.NEXT_PUBLIC_API_URL as string}/chat/messages`;
 
-export const fetchMessages = async ({ roomId, skip, pageSize }: Props) => {
+export const fetchMessages = async ({
+  roomId,
+  userId,
+  skip,
+  pageSize,
+}: Props) => {
   const debug = Debug('chat');
   try {
     const response = await axios.get<Message[]>(endpoint, {
-      params: { roomId, skip, pageSize },
+      params: { roomId, userId, skip, pageSize },
     });
 
     return response.data;

--- a/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
@@ -45,7 +45,7 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
     let ignore = false;
     if (!user) return;
 
-    const setupBlockedUsers = async (userId: number) => {
+    const setupBlockedUserIds = async (userId: number) => {
       const blockedUsers = await fetchBlockedUsers({
         userId: userId,
       });
@@ -55,7 +55,7 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
       }
     };
 
-    void setupBlockedUsers(user.id);
+    void setupBlockedUserIds(user.id);
 
     return () => {
       ignore = true;
@@ -155,10 +155,11 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
             #{currentRoom.name}
           </h3>
           <ChatMessageList
-            currentRoomId={currentRoom.id}
-            messages={messages}
-            setMessages={setMessages}
             socket={socket}
+            messages={messages}
+            currentRoomId={currentRoom.id}
+            setMessages={setMessages}
+            setBlockedUserIds={setBlockedUserIds}
           />
         </div>
         <ChatAlertCollapse show={error !== ''}>

--- a/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
@@ -18,6 +18,7 @@ import { ChatHeightStyle } from 'components/chat/utils/ChatHeightStyle';
 import { ChatErrorAlert } from 'components/chat/alert/ChatErrorAlert';
 import { ChatAlertCollapse } from 'components/chat/alert/ChatAlertCollapse';
 import { fetchDMRecipientName } from 'api/chat/fetchDMRecipientName';
+import { fetchBlockedUsers } from 'api/chat/fetchBlockedUsers';
 
 type Props = {
   socket: Socket;
@@ -36,6 +37,7 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
 }: Props) {
   const debug = useMemo(() => Debug('chat'), []);
   const [error, setError] = useState('');
+  const [blockedUserIds, setBlockedUserIds] = useState<number[]>([]);
   const { data: user } = useQueryUser();
   const [roomName, setRoomName] = useState('');
 
@@ -43,15 +45,45 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
     let ignore = false;
     if (!user) return;
 
-    // 他ユーザーからのメッセージを受け取る
+    const setupBlockedUsers = async (userId: number) => {
+      const blockedUsers = await fetchBlockedUsers({
+        userId: userId,
+      });
+      const ids = blockedUsers.map((user) => user.id);
+      if (!ignore) {
+        setBlockedUserIds(ids);
+      }
+    };
+
+    void setupBlockedUsers(user.id);
+
+    return () => {
+      ignore = true;
+    };
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    if (!currentRoom) return;
+
     socket.on('chat:receiveMessage', (message: Message) => {
       debug('chat:receiveMessage ', message, currentRoom);
 
-      // 現在画面に表示しているルームのメッセージだった場合にのみ追加する
-      if (message.roomId === currentRoom?.id) {
+      const isBlocked = blockedUserIds.includes(message.userId);
+      const isCurrentRoomMessage = message.roomId === currentRoom.id;
+      if (isCurrentRoomMessage && !isBlocked) {
         setMessages((prev) => [...prev, message]);
       }
     });
+
+    return () => {
+      socket.off('chat:receiveMessage');
+    };
+  }, [user, blockedUserIds, socket, debug, setMessages, currentRoom]);
+
+  useEffect(() => {
+    let ignore = false;
+    if (!user) return;
 
     const updateRoomName = async (room: CurrentRoom, userId: number) => {
       if (room.type === ChatroomType.DM) {
@@ -72,7 +104,6 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
     void updateRoomName(currentRoom, user.id);
 
     return () => {
-      socket.off('chat:receiveMessage');
       ignore = true;
     };
   }, [user, currentRoom, debug, setMessages, socket]);

--- a/frontend/components/chat/message-exchange/ChatMessageList.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageList.tsx
@@ -65,13 +65,11 @@ export const ChatMessageList = memo(function ChatMessageList({
   useEffect(() => {
     const ignore = false;
     socket.on('chat:blockUser', (userId: number) => {
-      console.log('chat:blockUser received messageList', userId);
       void initMessages(ignore);
       setBlockedUserIds((prev) => [...prev, userId]);
     });
 
     socket.on('chat:unblockUser', (userId: number) => {
-      console.log('chat:unblockUser received messageList', userId);
       void initMessages(ignore);
       setBlockedUserIds((prev) => prev.filter((id) => id !== userId));
     });


### PR DESCRIPTION
## 概要

- **before**
  - ブロックしたユーザーのメッセージが表示されていた。
- **after**
  - ブロックしたユーザーのメッセージを非表示にした。

## 対応箇所

- チャットルーム入室した時
- 上に画面をスクロールした時
- メッセージを受信した時
- ブロックを実行/解除した時

## 対応方法

### 初回取得時と上に画面をスクロールした時

- メッセージ取得処理でブロックしたユーザを弾くようにした。

### メッセージを受信した時

- ブロックしているユーザーのIDの配列をuseStateで管理する。
- 受信したメッセージの作成者と比較し、ブロックしたユーザーだったら表示させないようにした。

**余談**
- サーバー側でブロック状況に応じてメッセージ送信先を制御する手もある。 実装コストが高いため上記で対応した。

### ブロック実行/解除した時

- ブロック実行/解除したら、stateのブロックしたユーザーのIDを更新する。
- 入室時に行うメッセージ取得処理を行うことで、ブロックしたユーザのメッセージを表示させる。


## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/382

## demo

### メッセージを送信しても表示されないこと

https://user-images.githubusercontent.com/76232929/217266343-60d2c98b-e7c5-4b49-9e44-5f12a0862822.mov

### 入室時にメッセージが表示されないこと

https://user-images.githubusercontent.com/76232929/217266333-6189302e-6f22-4ee7-a10f-6a6d6ab2a12a.mov

