### PR TITLE
オーナーはチャットルームにパスワードを追加、削除できるようにする

### DIFF
--- a/backend/src/auth/auth.service.ts
+++ b/backend/src/auth/auth.service.ts
@@ -279,7 +279,7 @@ export class AuthService {
         },
         data: {
           has2FA: false,
-          secret2FA: undefined,
+          secret2FA: null,
         },
       });
     } catch {

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -540,8 +540,29 @@ export class ChatGateway {
   }
 
   /**
+   * protectedチャットルームのパスワードを削除する
+   * @param DeleteChatroomPasswordDto
+   */
+  @SubscribeMessage('chat:deletePassword')
+  async deletePassword(
+    @ConnectedSocket() client: Socket,
+    @MessageBody() dto: DeleteChatroomPasswordDto,
+  ): Promise<boolean> {
+    const publicRoom = await this.chatroomService.deletePassword(dto);
+    if (!publicRoom) return false;
+
+    const socketRoomName = this.generateSocketChatRoomName(publicRoom.id);
+    const deletedClientRoom = this.convertToClientChatroom(publicRoom);
+    this.server
+      .to(socketRoomName)
+      .emit('chat:deletePassword', deletedClientRoom);
+
+    return true;
+  }
+
+  /**
    * publicチャットルームのパスワードを追加する
-   * @param UpdateChatroomPasswordDto
+   * @param AddChatroomPasswordDto
    */
   @SubscribeMessage('chat:addPassword')
   async addPassword(
@@ -565,27 +586,6 @@ export class ChatGateway {
     const socketRoomName = this.generateSocketChatRoomName(updateRoom.id);
     const deletedClientRoom = this.convertToClientChatroom(updateRoom);
     this.server.to(socketRoomName).emit('chat:addPassword', deletedClientRoom);
-
-    return true;
-  }
-
-  /**
-   * protectedチャットルームのパスワードを削除する
-   * @param UpdateChatroomPasswordDto
-   */
-  @SubscribeMessage('chat:deletePassword')
-  async deletePassword(
-    @ConnectedSocket() client: Socket,
-    @MessageBody() dto: DeleteChatroomPasswordDto,
-  ): Promise<boolean> {
-    const publicRoom = await this.chatroomService.deletePassword(dto);
-    if (!publicRoom) return false;
-
-    const socketRoomName = this.generateSocketChatRoomName(publicRoom.id);
-    const deletedClientRoom = this.convertToClientChatroom(publicRoom);
-    this.server
-      .to(socketRoomName)
-      .emit('chat:deletePassword', deletedClientRoom);
 
     return true;
   }

--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -584,8 +584,8 @@ export class ChatGateway {
     if (!updateRoom) return false;
 
     const socketRoomName = this.generateSocketChatRoomName(updateRoom.id);
-    const deletedClientRoom = this.convertToClientChatroom(updateRoom);
-    this.server.to(socketRoomName).emit('chat:addPassword', deletedClientRoom);
+    const addedClientRoom = this.convertToClientChatroom(updateRoom);
+    this.server.to(socketRoomName).emit('chat:addPassword', addedClientRoom);
 
     return true;
   }

--- a/backend/src/chat/chatroom.service.ts
+++ b/backend/src/chat/chatroom.service.ts
@@ -271,7 +271,7 @@ export class ChatroomService {
 
     const publicRoom = await this.update({
       data: {
-        hashedPassword: undefined,
+        hashedPassword: null,
         type: ChatroomType.PUBLIC,
       },
       where: {

--- a/backend/src/chat/chatroom.service.ts
+++ b/backend/src/chat/chatroom.service.ts
@@ -179,7 +179,7 @@ export class ChatroomService {
       return undefined;
     }
 
-    if (dto.type === ChatroomType.PROTECTED) {
+    if (chatroom.type === ChatroomType.PROTECTED) {
       // Protectedの場合はパスワードが正しいことを確認する
       const isValid = await bcrypt.compare(
         dto.password,

--- a/backend/src/chat/chatroom.service.ts
+++ b/backend/src/chat/chatroom.service.ts
@@ -249,8 +249,8 @@ export class ChatroomService {
   }
 
   /**
-   * チャットルームのパスワードをする
-   * @param UpdateChatroomPasswordDto
+   * チャットルームのパスワードを削除する
+   * @param DeleteChatroomPasswordDto
    */
   async deletePassword(dto: DeleteChatroomPasswordDto): Promise<Chatroom> {
     const targetRoom = await this.findOne({

--- a/backend/src/chat/chatroom.service.ts
+++ b/backend/src/chat/chatroom.service.ts
@@ -13,6 +13,7 @@ import { JoinChatroomDto } from './dto/chatroom/join-chatroom.dto';
 import { DeleteChatroomDto } from './dto/chatroom/delete-chatroom.dto';
 import { UpdateChatroomPasswordDto } from './dto/chatroom/update-chatroom-password.dto';
 import { DeleteChatroomMemberDto } from './dto/chatroom/delete-chatroom-member.dto';
+import { DeleteChatroomPasswordDto } from './dto/chatroom/delete-chatroom-password.dto';
 
 @Injectable()
 export class ChatroomService {
@@ -245,6 +246,40 @@ export class ChatroomService {
     }
 
     return true;
+  }
+
+  /**
+   * チャットルームのパスワードをする
+   * @param UpdateChatroomPasswordDto
+   */
+  async deletePassword(dto: DeleteChatroomPasswordDto): Promise<Chatroom> {
+    const targetRoom = await this.findOne({
+      id: dto.chatroomId,
+    });
+    if (!targetRoom) {
+      return undefined;
+    }
+
+    // Oldパスワードが正しいことを確認する
+    const isValid = await bcrypt.compare(
+      dto.oldPassword,
+      targetRoom.hashedPassword,
+    );
+    if (!isValid) {
+      return undefined;
+    }
+
+    const publicRoom = await this.update({
+      data: {
+        hashedPassword: undefined,
+        type: ChatroomType.PUBLIC,
+      },
+      where: {
+        id: dto.chatroomId,
+      },
+    });
+
+    return publicRoom;
   }
 
   /**

--- a/backend/src/chat/dto/chatroom/add-chatroom-password.ts
+++ b/backend/src/chat/dto/chatroom/add-chatroom-password.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsNumber, IsString } from 'class-validator';
+
+export class AddChatroomPasswordDto {
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  newPassword: string;
+}

--- a/backend/src/chat/dto/chatroom/delete-chatroom-password.dto.ts
+++ b/backend/src/chat/dto/chatroom/delete-chatroom-password.dto.ts
@@ -1,0 +1,11 @@
+import { IsNotEmpty, IsString, IsNumber } from 'class-validator';
+
+export class DeleteChatroomPasswordDto {
+  @IsNumber()
+  @IsNotEmpty()
+  chatroomId: number;
+
+  @IsString()
+  @IsNotEmpty()
+  oldPassword: string;
+}

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -242,6 +242,21 @@ export const ChatroomListItem = memo(function ChatroomListItem({
     });
   };
 
+  const deletePassword = (oldPassword: string) => {
+    const deletePassword = {
+      chatroomId: room.id,
+      oldPassword: oldPassword,
+    };
+    socket.emit('chat:deletePassword', deletePassword, (isSuccess: boolean) => {
+      if (!isSuccess) {
+        setError('Failed to delete password.');
+
+        return;
+      }
+      setSuccess('Password has been deleted successfully.');
+    });
+  };
+
   const banUser = (userId: number) => {
     const banUserInfo = {
       userId: userId,
@@ -388,6 +403,7 @@ export const ChatroomListItem = memo(function ChatroomListItem({
           addAdmin={addAdmin}
           changePassword={changePassword}
           addPassword={addPassword}
+          deletePassword={deletePassword}
           banUser={banUser}
           unbanUser={unbanUser}
           muteUser={muteUser}

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -227,6 +227,21 @@ export const ChatroomListItem = memo(function ChatroomListItem({
     );
   };
 
+  const addPassword = (newPassword: string) => {
+    const adddPasswordInfo = {
+      chatroomId: room.id,
+      newPassword: newPassword,
+    };
+    socket.emit('chat:addPassword', adddPasswordInfo, (isSuccess: boolean) => {
+      if (!isSuccess) {
+        setError('Failed to add password.');
+
+        return;
+      }
+      setSuccess('Password has been added successfully.');
+    });
+  };
+
   const banUser = (userId: number) => {
     const banUserInfo = {
       userId: userId,
@@ -372,6 +387,7 @@ export const ChatroomListItem = memo(function ChatroomListItem({
           addFriend={addFriend}
           addAdmin={addAdmin}
           changePassword={changePassword}
+          addPassword={addPassword}
           banUser={banUser}
           unbanUser={unbanUser}
           muteUser={muteUser}

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -227,21 +227,6 @@ export const ChatroomListItem = memo(function ChatroomListItem({
     );
   };
 
-  const addPassword = (newPassword: string) => {
-    const adddPasswordInfo = {
-      chatroomId: room.id,
-      newPassword: newPassword,
-    };
-    socket.emit('chat:addPassword', adddPasswordInfo, (isSuccess: boolean) => {
-      if (!isSuccess) {
-        setError('Failed to add password.');
-
-        return;
-      }
-      setSuccess('Password has been added successfully.');
-    });
-  };
-
   const deletePassword = (oldPassword: string) => {
     const deletePassword = {
       chatroomId: room.id,
@@ -254,6 +239,21 @@ export const ChatroomListItem = memo(function ChatroomListItem({
         return;
       }
       setSuccess('Password has been deleted successfully.');
+    });
+  };
+
+  const addPassword = (newPassword: string) => {
+    const adddPasswordInfo = {
+      chatroomId: room.id,
+      newPassword: newPassword,
+    };
+    socket.emit('chat:addPassword', adddPasswordInfo, (isSuccess: boolean) => {
+      if (!isSuccess) {
+        setError('Failed to add password.');
+
+        return;
+      }
+      setSuccess('Password has been added successfully.');
     });
   };
 
@@ -402,8 +402,8 @@ export const ChatroomListItem = memo(function ChatroomListItem({
           addFriend={addFriend}
           addAdmin={addAdmin}
           changePassword={changePassword}
-          addPassword={addPassword}
           deletePassword={deletePassword}
+          addPassword={addPassword}
           banUser={banUser}
           unbanUser={unbanUser}
           muteUser={muteUser}

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -42,8 +42,8 @@ type Props = {
     newPassword: string,
     checkPassword: string,
   ) => void;
-  addPassword: (newPassword: string) => void;
   deletePassword: (oldPassword: string) => void;
+  addPassword: (newPassword: string) => void;
   banUser: (userId: number) => void;
   unbanUser: (userId: number) => void;
   muteUser: (userId: number) => void;
@@ -338,11 +338,11 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       case ChatroomSetting.CHANGE_PASSWORD:
         changePassword(oldPassword, newPassword, checkPassword);
         break;
-      case ChatroomSetting.ADD_PASSWORD:
-        addPassword(newPassword);
-        break;
       case ChatroomSetting.DELETE_PASSWORD:
         deletePassword(oldPassword);
+        break;
+      case ChatroomSetting.ADD_PASSWORD:
+        addPassword(newPassword);
         break;
       case ChatroomSetting.MUTE_USER:
         muteUser(Number(selectedUserId));
@@ -465,17 +465,6 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
             </DialogContent>
           </>
         )}
-        {selectedRoomSetting === ChatroomSetting.ADD_PASSWORD && (
-          <DialogContent>
-            <ChatPasswordForm
-              control={control}
-              inputName="newPassword"
-              labelName="New Password"
-              error={errors.newPassword}
-              helperText={passwordHelper}
-            />
-          </DialogContent>
-        )}
         {selectedRoomSetting === ChatroomSetting.DELETE_PASSWORD && (
           <DialogContent>
             <ChatPasswordForm
@@ -483,6 +472,17 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
               inputName="oldPassword"
               labelName="Old Password"
               error={errors.oldPassword}
+              helperText={passwordHelper}
+            />
+          </DialogContent>
+        )}
+        {selectedRoomSetting === ChatroomSetting.ADD_PASSWORD && (
+          <DialogContent>
+            <ChatPasswordForm
+              control={control}
+              inputName="newPassword"
+              labelName="New Password"
+              error={errors.newPassword}
               helperText={passwordHelper}
             />
           </DialogContent>

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -43,6 +43,7 @@ type Props = {
     checkPassword: string,
   ) => void;
   addPassword: (newPassword: string) => void;
+  deletePassword: (oldPassword: string) => void;
   banUser: (userId: number) => void;
   unbanUser: (userId: number) => void;
   muteUser: (userId: number) => void;
@@ -65,6 +66,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   addFriend,
   addAdmin,
   changePassword,
+  deletePassword,
   addPassword,
   banUser,
   unbanUser,
@@ -97,13 +99,15 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   const schema = z.object({
     oldPassword: z.string().refine(
       (value: string) =>
-        selectedRoomSetting !== ChatroomSetting.CHANGE_PASSWORD ||
+        (selectedRoomSetting !== ChatroomSetting.CHANGE_PASSWORD &&
+          selectedRoomSetting !== ChatroomSetting.DELETE_PASSWORD) ||
         value.length >= 5,
       () => ({ message: errorInputPassword }),
     ),
     newPassword: z.string().refine(
       (value: string) =>
-        selectedRoomSetting !== ChatroomSetting.CHANGE_PASSWORD ||
+        (selectedRoomSetting !== ChatroomSetting.CHANGE_PASSWORD &&
+          selectedRoomSetting !== ChatroomSetting.ADD_PASSWORD) ||
         value.length >= 5,
       () => ({ message: errorInputPassword }),
     ),
@@ -337,6 +341,9 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       case ChatroomSetting.ADD_PASSWORD:
         addPassword(newPassword);
         break;
+      case ChatroomSetting.DELETE_PASSWORD:
+        deletePassword(oldPassword);
+        break;
       case ChatroomSetting.MUTE_USER:
         muteUser(Number(selectedUserId));
         break;
@@ -465,6 +472,17 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
               inputName="newPassword"
               labelName="New Password"
               error={errors.newPassword}
+              helperText={passwordHelper}
+            />
+          </DialogContent>
+        )}
+        {selectedRoomSetting === ChatroomSetting.DELETE_PASSWORD && (
+          <DialogContent>
+            <ChatPasswordForm
+              control={control}
+              inputName="oldPassword"
+              labelName="Old Password"
+              error={errors.oldPassword}
               helperText={passwordHelper}
             />
           </DialogContent>

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -42,6 +42,7 @@ type Props = {
     newPassword: string,
     checkPassword: string,
   ) => void;
+  addPassword: (newPassword: string) => void;
   banUser: (userId: number) => void;
   unbanUser: (userId: number) => void;
   muteUser: (userId: number) => void;
@@ -64,6 +65,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
   addFriend,
   addAdmin,
   changePassword,
+  addPassword,
   banUser,
   unbanUser,
   muteUser,
@@ -332,6 +334,9 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       case ChatroomSetting.CHANGE_PASSWORD:
         changePassword(oldPassword, newPassword, checkPassword);
         break;
+      case ChatroomSetting.ADD_PASSWORD:
+        addPassword(newPassword);
+        break;
       case ChatroomSetting.MUTE_USER:
         muteUser(Number(selectedUserId));
         break;
@@ -452,6 +457,17 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
               />
             </DialogContent>
           </>
+        )}
+        {selectedRoomSetting === ChatroomSetting.ADD_PASSWORD && (
+          <DialogContent>
+            <ChatPasswordForm
+              control={control}
+              inputName="newPassword"
+              labelName="New Password"
+              error={errors.newPassword}
+              helperText={passwordHelper}
+            />
+          </DialogContent>
         )}
         {selectedRoomSetting === ChatroomSetting.BAN_USER && (
           <ChatroomSettingDetailDialog

--- a/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
@@ -114,6 +114,12 @@ export const ChatroomSettingItems = memo(function ChatroomSettingItems({
           {ChatroomSetting.ADD_PASSWORD}
         </MenuItem>
       )}
+      {/* PROTECTEDのルームのみ選択可能 */}
+      {isOwner && roomType === ChatroomType.PROTECTED && (
+        <MenuItem value={ChatroomSetting.DELETE_PASSWORD}>
+          {ChatroomSetting.DELETE_PASSWORD}
+        </MenuItem>
+      )}
       {/* 非公開のルームのみフレンド追加ボタンが選択可能 */}
       {isOwner && roomType === ChatroomType.PRIVATE && (
         <MenuItem value={ChatroomSetting.ADD_FRIEND}>

--- a/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
@@ -43,6 +43,7 @@ const DMSettingItems = memo(function DMSettingItems({
  * - friendを入室させる：PrivateかつOwnerのみ
  * - ミュートする：Owner, Admin（DMでは表示しない）
  * - BANする：Owner, Admin（DMでは表示しない）
+ * - Passwordを追加する：Owner
  */
 export const ChatroomSettingItems = memo(function ChatroomSettingItems({
   isAdmin,
@@ -105,6 +106,12 @@ export const ChatroomSettingItems = memo(function ChatroomSettingItems({
       {isOwner && roomType === ChatroomType.PROTECTED && (
         <MenuItem value={ChatroomSetting.CHANGE_PASSWORD}>
           {ChatroomSetting.CHANGE_PASSWORD}
+        </MenuItem>
+      )}
+      {/* PUBLICのルームのみ選択可能 */}
+      {isOwner && roomType === ChatroomType.PUBLIC && (
+        <MenuItem value={ChatroomSetting.ADD_PASSWORD}>
+          {ChatroomSetting.ADD_PASSWORD}
         </MenuItem>
       )}
       {/* 非公開のルームのみフレンド追加ボタンが選択可能 */}

--- a/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingItems.tsx
@@ -40,10 +40,10 @@ const DMSettingItems = memo(function DMSettingItems({
  * - チャットルームを削除する： Owner, DMの場合はNormalも可能
  * - チャットルームを退出する： 全てのユーザーが実行可能
  * - adminを設定する：Owner
+ * - Passwordを変更、削除、追加する：Owner
  * - friendを入室させる：PrivateかつOwnerのみ
  * - ミュートする：Owner, Admin（DMでは表示しない）
  * - BANする：Owner, Admin（DMでは表示しない）
- * - Passwordを追加する：Owner
  */
 export const ChatroomSettingItems = memo(function ChatroomSettingItems({
   isAdmin,
@@ -108,16 +108,16 @@ export const ChatroomSettingItems = memo(function ChatroomSettingItems({
           {ChatroomSetting.CHANGE_PASSWORD}
         </MenuItem>
       )}
-      {/* PUBLICのルームのみ選択可能 */}
-      {isOwner && roomType === ChatroomType.PUBLIC && (
-        <MenuItem value={ChatroomSetting.ADD_PASSWORD}>
-          {ChatroomSetting.ADD_PASSWORD}
-        </MenuItem>
-      )}
-      {/* PROTECTEDのルームのみ選択可能 */}
+      {/* パスワードで保護されたルームのみ選択可能 */}
       {isOwner && roomType === ChatroomType.PROTECTED && (
         <MenuItem value={ChatroomSetting.DELETE_PASSWORD}>
           {ChatroomSetting.DELETE_PASSWORD}
+        </MenuItem>
+      )}
+      {/* 公開されたルームのみ選択可能 */}
+      {isOwner && roomType === ChatroomType.PUBLIC && (
+        <MenuItem value={ChatroomSetting.ADD_PASSWORD}>
+          {ChatroomSetting.ADD_PASSWORD}
         </MenuItem>
       )}
       {/* 非公開のルームのみフレンド追加ボタンが選択可能 */}

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -86,6 +86,17 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       );
     });
 
+    // パスワードが追加されたときにchange passwordを可能にする
+    socket.on('chat:addPassword', (protectedRoom: Chatroom) => {
+      debug('addPassword', protectedRoom);
+
+      setRooms((prevRooms) =>
+        prevRooms.map((room) => {
+          return room.id === protectedRoom.id ? protectedRoom : room;
+        }),
+      );
+    });
+
     // setupが終わったら入室中のチャットルーム一覧を取得する
     socket.emit('chat:getJoinedRooms', { userId: user.id });
 
@@ -94,6 +105,7 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       socket.off('chat:updateSideBarRooms');
       socket.off('chat:joinRoomFromOtherUser');
       socket.off('chat:changeRoomOwner');
+      socket.off('chat:addPassword');
     };
   }, [user, debug, setCurrentRoom, setMessages, socket]);
 

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -86,17 +86,6 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       );
     });
 
-    // パスワードが追加されたときにchange passwordを可能にする
-    socket.on('chat:addPassword', (protectedRoom: Chatroom) => {
-      debug('addPassword', protectedRoom);
-
-      setRooms((prevRooms) =>
-        prevRooms.map((room) => {
-          return room.id === protectedRoom.id ? protectedRoom : room;
-        }),
-      );
-    });
-
     // パスワードが消去されたときにadd passwordを可能にする
     socket.on('chat:deletePassword', (publicRoom: Chatroom) => {
       debug('deletePassword', publicRoom);
@@ -104,6 +93,17 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       setRooms((prevRooms) =>
         prevRooms.map((room) => {
           return room.id === publicRoom.id ? publicRoom : room;
+        }),
+      );
+    });
+
+    // パスワードが追加されたときにchange passwordを可能にする
+    socket.on('chat:addPassword', (protectedRoom: Chatroom) => {
+      debug('addPassword', protectedRoom);
+
+      setRooms((prevRooms) =>
+        prevRooms.map((room) => {
+          return room.id === protectedRoom.id ? protectedRoom : room;
         }),
       );
     });
@@ -116,8 +116,8 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       socket.off('chat:updateSideBarRooms');
       socket.off('chat:joinRoomFromOtherUser');
       socket.off('chat:changeRoomOwner');
-      socket.off('chat:addPassword');
       socket.off('chat:deletePassword');
+      socket.off('chat:addPassword');
     };
   }, [user, debug, setCurrentRoom, setMessages, socket]);
 

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -97,6 +97,17 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       );
     });
 
+    // パスワードが消去されたときにadd passwordを可能にする
+    socket.on('chat:deletePassword', (publicRoom: Chatroom) => {
+      debug('deletePassword', publicRoom);
+
+      setRooms((prevRooms) =>
+        prevRooms.map((room) => {
+          return room.id === publicRoom.id ? publicRoom : room;
+        }),
+      );
+    });
+
     // setupが終わったら入室中のチャットルーム一覧を取得する
     socket.emit('chat:getJoinedRooms', { userId: user.id });
 
@@ -106,6 +117,7 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       socket.off('chat:joinRoomFromOtherUser');
       socket.off('chat:changeRoomOwner');
       socket.off('chat:addPassword');
+      socket.off('chat:deletePassword');
     };
   }, [user, debug, setCurrentRoom, setMessages, socket]);
 

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -47,8 +47,8 @@ export const ChatroomSetting = {
   LEAVE_ROOM: 'Leave Room',
   ADD_FRIEND: 'Add Friend', // private room
   CHANGE_PASSWORD: 'Change Password', // protected room
-  ADD_PASSWORD: 'Add Password',
-  DELETE_PASSWORD: 'Delete Password',
+  DELETE_PASSWORD: 'Delete Password', // protected room
+  ADD_PASSWORD: 'Add Password', // public room
   SET_ADMIN: 'Set Admin',
   MUTE_USER: 'Mute User',
   UNMUTE_USER: 'Unmute User',

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -40,7 +40,7 @@ export const ChatroomType = {
   DM: 'DM',
 } as const;
 
-export type ChatroomType = typeof ChatroomType[keyof typeof ChatroomType];
+export type ChatroomType = (typeof ChatroomType)[keyof typeof ChatroomType];
 
 export const ChatroomSetting = {
   DELETE_ROOM: 'Delete Room',
@@ -52,10 +52,11 @@ export const ChatroomSetting = {
   UNMUTE_USER: 'Unmute User',
   BAN_USER: 'Ban User',
   UNBAN_USER: 'Unban User',
+  ADD_PASSWORD: 'Add Password',
 } as const;
 
 export type ChatroomSetting =
-  typeof ChatroomSetting[keyof typeof ChatroomSetting];
+  (typeof ChatroomSetting)[keyof typeof ChatroomSetting];
 
 export type ChatUser = {
   id: number;
@@ -68,4 +69,4 @@ export const ChatBlockSetting = {
 } as const;
 
 export type ChatBlockSetting =
-  typeof ChatBlockSetting[keyof typeof ChatBlockSetting];
+  (typeof ChatBlockSetting)[keyof typeof ChatBlockSetting];

--- a/frontend/types/chat.ts
+++ b/frontend/types/chat.ts
@@ -47,12 +47,13 @@ export const ChatroomSetting = {
   LEAVE_ROOM: 'Leave Room',
   ADD_FRIEND: 'Add Friend', // private room
   CHANGE_PASSWORD: 'Change Password', // protected room
+  ADD_PASSWORD: 'Add Password',
+  DELETE_PASSWORD: 'Delete Password',
   SET_ADMIN: 'Set Admin',
   MUTE_USER: 'Mute User',
   UNMUTE_USER: 'Unmute User',
   BAN_USER: 'Ban User',
   UNBAN_USER: 'Unban User',
-  ADD_PASSWORD: 'Add Password',
 } as const;
 
 export type ChatroomSetting =


### PR DESCRIPTION
チャンネルのオーナーが
* PUBLICのルームに対してパスワードを設定してPROTECTEDにする。
* PROTECTEDのルームからパスワードを消去してPUBLICにする。

以上のことができるようにしました。


https://user-images.githubusercontent.com/64348608/217283428-0d21e5f6-3ae1-418b-90aa-bac28e31961d.mp4



* resolve #383 