### PR TITLE
FriendSidebarから進行中のゲームを観戦できるようにした

### DIFF
--- a/backend/src/game/dto/watch-friend-game.dto.ts
+++ b/backend/src/game/dto/watch-friend-game.dto.ts
@@ -1,0 +1,7 @@
+import { IsNotEmpty, IsNumber } from 'class-validator';
+
+export class WatchFriendGameDto {
+  @IsNumber()
+  @IsNotEmpty()
+  friendId: number;
+}

--- a/backend/src/game/types/game.ts
+++ b/backend/src/game/types/game.ts
@@ -97,3 +97,10 @@ export type Invitation = {
 export type SocketAuth = {
   userId: number;
 };
+
+export type FriendGameInfo = {
+  player1Name: string;
+  player2Name: string;
+  gameState: GameState;
+  gameSetting: GameSetting;
+};

--- a/frontend/components/chat/friend/FriendInfoDialog.tsx
+++ b/frontend/components/chat/friend/FriendInfoDialog.tsx
@@ -14,18 +14,22 @@ import {
 } from '@mui/material';
 import { blue } from '@mui/material/colors';
 import { Friend } from 'types/friend';
+import { UserStatus } from 'types/game';
 
 type Props = {
   friend: Friend;
+  friendStatus: UserStatus;
   open: boolean;
   onClose: () => void;
   inviteGame: (friend: Friend) => void;
+  watchGame: (friend: Friend) => void;
   directMessage: (friend: Friend) => void;
 };
 
 const FRIEND_ACTIONS = {
   PROFILE: 'Profile',
   INVITE_GAME: 'Invite Game',
+  WATCH_GAME: 'Watch Game',
   DM: 'Direct Message',
 } as const;
 
@@ -33,9 +37,11 @@ type FriendActions = (typeof FRIEND_ACTIONS)[keyof typeof FRIEND_ACTIONS];
 
 export const FriendInfoDialog = memo(function FriendInfoDialog({
   friend,
+  friendStatus,
   open,
   onClose,
   inviteGame,
+  watchGame,
   directMessage,
 }: Props) {
   const [actionType, setActionType] = useState<FriendActions>(
@@ -71,6 +77,9 @@ export const FriendInfoDialog = memo(function FriendInfoDialog({
         case 'Invite Game':
           inviteGame(friend);
           break;
+        case 'Watch Game':
+          watchGame(friend);
+          break;
         case 'Direct Message':
           directMessage(friend);
           break;
@@ -96,7 +105,11 @@ export const FriendInfoDialog = memo(function FriendInfoDialog({
             onChange={handleChangeType}
           >
             <MenuItem value="Profile">Profile</MenuItem>
-            <MenuItem value="Invite Game">Invite Game</MenuItem>
+            {friendStatus !== UserStatus.PLAYING ? (
+              <MenuItem value="Invite Game">Invite Game</MenuItem>
+            ) : (
+              <MenuItem value="Watch Game">Watch Game</MenuItem>
+            )}
             <MenuItem value="Direct Message">Direct Message</MenuItem>
           </Select>
         </FormControl>

--- a/frontend/components/game/home/Watch.tsx
+++ b/frontend/components/game/home/Watch.tsx
@@ -15,15 +15,7 @@ import { useSocketStore } from 'store/game/ClientSocket';
 import { useGameSettingStore } from 'store/game/GameSetting';
 import { usePlayerNamesStore } from 'store/game/PlayerNames';
 import { PlayState, usePlayStateStore } from 'store/game/PlayState';
-import { GameSetting } from 'types/game';
-
-type WatchInfo = {
-  roomName: string;
-  name1: string;
-  name2: string;
-};
-
-type GameState = 'Setting' | 'Playing';
+import { GameSetting, WatchInfo, GameState } from 'types/game';
 
 export const Watch = () => {
   const { socket } = useSocketStore();
@@ -61,7 +53,7 @@ export const Watch = () => {
         if (user === undefined) {
           return;
         }
-        if (gameState === 'Setting') {
+        if (gameState === GameState.SETTING) {
           updatePlayState(PlayState.stateStandingBy);
         } else {
           updatePlayState(PlayState.statePlaying);

--- a/frontend/types/game.ts
+++ b/frontend/types/game.ts
@@ -5,7 +5,7 @@ export const DifficultyLevel = {
 } as const;
 
 export type DifficultyLevel =
-  typeof DifficultyLevel[keyof typeof DifficultyLevel];
+  (typeof DifficultyLevel)[keyof typeof DifficultyLevel];
 
 export const UserStatus = {
   ONLINE: 'ONLINE',
@@ -13,7 +13,7 @@ export const UserStatus = {
   OFFLINE: 'OFFLINE',
 } as const;
 
-export type UserStatus = typeof UserStatus[keyof typeof UserStatus];
+export type UserStatus = (typeof UserStatus)[keyof typeof UserStatus];
 
 export type GameSetting = {
   difficulty: DifficultyLevel;
@@ -78,3 +78,16 @@ export type GameParameters = {
 export type SocketAuth = {
   userId: number;
 };
+
+export type WatchInfo = {
+  roomName: string;
+  name1: string;
+  name2: string;
+};
+
+export const GameState = {
+  SETTING: 'Setting',
+  PLAYING: 'Playing',
+} as const;
+
+export type GameState = (typeof GameState)[keyof typeof GameState];


### PR DESCRIPTION
## 概要

### Before

Chat画面から進行中のゲームに観戦に行くことはできなかった。

### After

Friend登録したユーザーがゲーム中の場合には、Invite GameのActionがWatch Gameに変わり、それをクリックすると進行中のゲームを観戦できるようにした。

## Demo

https://user-images.githubusercontent.com/15176241/217681780-064b418b-80f9-4723-bd4f-bb3e4946c822.mov

## 備考

当初、FriendSidebarの下半分をWatchのコンポーネントにすることを考えていたが、Watch側がpagenationとか諸々機能を含んでいるために、そのまま埋め込むのが難しかったため、正攻法での実装に方針転換した。

## 関連イシュー

- resolve #390 