### PR TITLE
adminをmute/ban可能にした

### DIFF
--- a/backend/src/chat/chat.controller.ts
+++ b/backend/src/chat/chat.controller.ts
@@ -113,22 +113,19 @@ export class ChatController {
    * Muteできるユーザ一覧を返す
    * - Muteされていない
    * - Ownerではない
-   * - Adminではない
    * @param roomId
    */
   @Get('can-mute')
-  async findNotMutedUsers(
+  async findCanMuteUsers(
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<ChatUser[]> {
-    const adminUsers = await this.adminService.findAdmins(roomId);
     const mutedUsers = await this.muteService.findMutedUsers(roomId);
     const chatroomOwner = await this.chatroomService.findChatroomOwner(roomId);
 
-    const adminIds = adminUsers.map((admin) => admin.userId);
     const mutedIds = mutedUsers.map((user) => user.id);
     const ownerId = chatroomOwner.id;
 
-    const excludeIdSets = new Set([...adminIds, ...mutedIds, ownerId]);
+    const excludeIdSets = new Set([...mutedIds, ownerId]);
     const excludeIds = [...excludeIdSets];
 
     // すべてを満たさないUser一覧を取得する
@@ -160,22 +157,19 @@ export class ChatController {
    * Banされていないユーザ一覧を返す
    * - Banされていない
    * - Ownerではない
-   * - Adminではない
    * @param roomId
    */
   @Get('can-ban')
-  async findNotBannedUsers(
+  async findCanBanUsers(
     @Query('roomId', ParseIntPipe) roomId: number,
   ): Promise<ChatUser[]> {
-    const adminUsers = await this.adminService.findAdmins(roomId);
     const bannedUsers = await this.banService.findBannedUsers(roomId);
     const chatroomOwner = await this.chatroomService.findChatroomOwner(roomId);
 
-    const adminIds = adminUsers.map((admin) => admin.userId);
     const bannedIds = bannedUsers.map((user) => user.id);
     const ownerId = chatroomOwner.id;
 
-    const excludeIdSets = new Set([...adminIds, ...bannedIds, ownerId]);
+    const excludeIdSets = new Set([...bannedIds, ownerId]);
     const excludeIds = [...excludeIdSets];
 
     // すべてを満たさないUser一覧を取得する

--- a/frontend/components/chat/chatroom/ChatroomListItem.tsx
+++ b/frontend/components/chat/chatroom/ChatroomListItem.tsx
@@ -78,14 +78,13 @@ export const ChatroomListItem = memo(function ChatroomListItem({
     if (!user) return;
 
     socket.on('chat:addAdmin', (chatroomId: number) => {
-      console.log('chat:addAdmin', chatroomId, room.id);
       if (room.id !== chatroomId) {
         return;
       }
       setIsAdmin(true);
     });
+
     socket.on('chat:revokeAdmin', (chatroomId: number) => {
-      console.log('chat:revokeAdmin', chatroomId, room.id);
       if (room.id !== chatroomId) {
         return;
       }

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -119,6 +119,13 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     ),
   });
 
+  useEffect(() => {
+    // ダイアログが閉じられたらその都度、初期値に戻す
+    if (!open) {
+      setSelectedRoomSetting(initRoomSettingState);
+    }
+  }, [open, initRoomSettingState]);
+
   const expectYourself = useCallback(
     (ChatUsers: ChatUser[]) => {
       return ChatUsers.filter((u) => u.id !== user?.id);

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -126,7 +126,7 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
     }
   }, [open, initRoomSettingState]);
 
-  const expectYourself = useCallback(
+  const excludeYourself = useCallback(
     (ChatUsers: ChatUser[]) => {
       return ChatUsers.filter((u) => u.id !== user?.id);
     },
@@ -155,10 +155,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       });
 
       if (!ignore) {
-        setNotAdminUsers(expectYourself(canSetAdminUsers));
+        setNotAdminUsers(excludeYourself(canSetAdminUsers));
       }
     },
-    [user, room.id, expectYourself],
+    [user, room.id, excludeYourself],
   );
 
   const reloadCanBanUsers = useCallback(
@@ -169,10 +169,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setNotBannedUsers(expectYourself(canBanUsers));
+        setNotBannedUsers(excludeYourself(canBanUsers));
       }
     },
-    [user, room.id, expectYourself],
+    [user, room.id, excludeYourself],
   );
 
   const reloadCanUnbanUsers = useCallback(
@@ -181,10 +181,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setBannedUsers(expectYourself(bannedUsers));
+        setBannedUsers(excludeYourself(bannedUsers));
       }
     },
-    [room.id, expectYourself],
+    [room.id, excludeYourself],
   );
 
   const reloadCanMuteUsers = useCallback(
@@ -196,10 +196,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       });
 
       if (!ignore) {
-        setNotMutedUsers(expectYourself(canMuteUsers));
+        setNotMutedUsers(excludeYourself(canMuteUsers));
       }
     },
-    [user, room.id, expectYourself],
+    [user, room.id, excludeYourself],
   );
 
   const reloadCanUnmuteUsers = useCallback(
@@ -208,10 +208,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setMutedUsers(expectYourself(mutedUsers));
+        setMutedUsers(excludeYourself(mutedUsers));
       }
     },
-    [room.id, expectYourself],
+    [room.id, excludeYourself],
   );
 
   const reloadCanSetOwnerUsers = useCallback(
@@ -220,10 +220,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setActiveUsers(expectYourself(canSetOwnerUsers));
+        setActiveUsers(excludeYourself(canSetOwnerUsers));
       }
     },
-    [room.id, expectYourself],
+    [room.id, excludeYourself],
   );
 
   // 設定項目を選択した時に対応するユーザ一覧を取得する

--- a/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSettingDialog.tsx
@@ -118,16 +118,13 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       () => ({ message: errorInputPassword }),
     ),
   });
-  // TODO: 余裕あったら以下を使えるようにする
-  // チェック用と新規のパスワードと同じこと
-  // .superRefine(({ newPassword, checkPassword }, ctx) => {
-  //   if (newPassword !== checkPassword) {
-  //     ctx.addIssue({
-  //       code: 'custom',
-  //       message: 'The passwords did not match',
-  //     });
-  //   }
-  // });
+
+  const expectYourself = useCallback(
+    (ChatUsers: ChatUser[]) => {
+      return ChatUsers.filter((u) => u.id !== user?.id);
+    },
+    [user],
+  );
 
   const reloadFriends = useCallback(
     async (userId: number, ignore: boolean) => {
@@ -151,10 +148,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       });
 
       if (!ignore) {
-        setNotAdminUsers(canSetAdminUsers);
+        setNotAdminUsers(expectYourself(canSetAdminUsers));
       }
     },
-    [user, room.id],
+    [user, room.id, expectYourself],
   );
 
   const reloadCanBanUsers = useCallback(
@@ -165,10 +162,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setNotBannedUsers(canBanUsers);
+        setNotBannedUsers(expectYourself(canBanUsers));
       }
     },
-    [user, room.id],
+    [user, room.id, expectYourself],
   );
 
   const reloadCanUnbanUsers = useCallback(
@@ -177,10 +174,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setBannedUsers(bannedUsers);
+        setBannedUsers(expectYourself(bannedUsers));
       }
     },
-    [room.id],
+    [room.id, expectYourself],
   );
 
   const reloadCanMuteUsers = useCallback(
@@ -192,10 +189,10 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
       });
 
       if (!ignore) {
-        setNotMutedUsers(canMuteUsers);
+        setNotMutedUsers(expectYourself(canMuteUsers));
       }
     },
-    [user, room.id],
+    [user, room.id, expectYourself],
   );
 
   const reloadCanUnmuteUsers = useCallback(
@@ -204,25 +201,22 @@ export const ChatroomSettingDialog = memo(function ChatroomSettingDialog({
         roomId: room.id,
       });
       if (!ignore) {
-        setMutedUsers(mutedUsers);
+        setMutedUsers(expectYourself(mutedUsers));
       }
     },
-    [room.id],
+    [room.id, expectYourself],
   );
 
   const reloadCanSetOwnerUsers = useCallback(
     async (ignore: boolean) => {
-      const activeUsers = await fetchCanSetOwnerUsers({
+      const canSetOwnerUsers = await fetchCanSetOwnerUsers({
         roomId: room.id,
       });
-      const activeNotOwnerUsers = activeUsers.filter(
-        (user) => user.id !== room.ownerId,
-      );
       if (!ignore) {
-        setActiveUsers(activeNotOwnerUsers);
+        setActiveUsers(expectYourself(canSetOwnerUsers));
       }
     },
-    [room.id, room.ownerId],
+    [room.id, expectYourself],
   );
 
   // 設定項目を選択した時に対応するユーザ一覧を取得する

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -43,11 +43,6 @@ const Chat: NextPage = () => {
       socket.emit('chat:initSocket', user.id);
     });
 
-    socket.on('chat:banned', () => {
-      setError('You are banned.');
-      setCurrentRoom(undefined);
-    });
-
     // バックエンドのvalidation errorをチャッチ
     socket.on('exception', (data: { status: string; message: string }) => {
       debug('receive exception: %o', data);
@@ -56,10 +51,25 @@ const Chat: NextPage = () => {
 
     return () => {
       socket.off('chat:handleConnection');
-      socket.off('chat:banned');
       socket.off('exception');
     };
   }, [user, socket, debug]);
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.on('chat:banned', (chatroomId: number) => {
+      if (chatroomId !== currentRoom?.id) {
+        return;
+      }
+      setError('You are banned.');
+      setCurrentRoom(undefined);
+    });
+
+    return () => {
+      socket.off('chat:banned');
+    };
+  }, [socket, currentRoom?.id]);
 
   if (socket === undefined || user === undefined) {
     return <Loading fullHeight />;


### PR DESCRIPTION
## 概要
- **before**
  - adminはmute/banの対象外だった。
- **after**
  - adminもmute/banの対象とした。

## 関連issue
- resolve https://github.com/ryo-manba/ft_transcendence/issues/388

## demo

https://user-images.githubusercontent.com/76232929/217834774-0825f334-38a5-40fe-a00d-cbf45d895d52.mov

