### PR TITLE
DMのチャットルーム名を修正した

### DIFF
--- a/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
+++ b/frontend/components/chat/message-exchange/ChatMessageExchange.tsx
@@ -152,7 +152,7 @@ export const ChatMessageExchange = memo(function ChatMessageExchange({
       >
         <div className="mb-4 flex grow-[1] flex-col">
           <h3 className="my-2 ml-1 overflow-hidden text-ellipsis whitespace-nowrap underline">
-            #{currentRoom.name}
+            #{roomName}
           </h3>
           <ChatMessageList
             socket={socket}


### PR DESCRIPTION
## 概要

### Before

DMのチャットルーム名がユーザー名をアンダースコアで連結したものになってしまっていた

### After

DMのチャットルーム名をDM相手のユーザー名に修正

## Demo

### Before

<img width="1624" alt="Screenshot 2023-02-13 at 23 44 28" src="https://user-images.githubusercontent.com/15176241/218491883-9597d641-1c24-4031-b339-987f13ba5a4f.png">

### After

<img width="1624" alt="Screenshot 2023-02-13 at 23 46 27" src="https://user-images.githubusercontent.com/15176241/218492031-74dd1325-3e8d-4356-ae4c-fa9a46c71f64.png">