### PR TITLE
BanまたはKickされたユーザー側のnotificationを修正した

### DIFF
--- a/backend/src/chat/chat.gateway.ts
+++ b/backend/src/chat/chat.gateway.ts
@@ -631,16 +631,19 @@ export class ChatGateway {
       userId: dto.userId,
       chatroomId: dto.chatroomId,
     };
-    const isAdmin = await this.adminService.isAdmin(isAdminDto);
-    if (!isAdmin) {
-      return true;
-    }
+
     this.server
       .to(this.generateSocketUserRoomName(dto.userId))
       .emit('chat:banned', dto.chatroomId);
-    const isSuccess = this.revokeAdmin(dto.userId, dto.chatroomId);
 
-    return isSuccess;
+    const isAdmin = await this.adminService.isAdmin(isAdminDto);
+    if (!isAdmin) {
+      return true;
+    } else {
+      const isSuccess = this.revokeAdmin(dto.userId, dto.chatroomId);
+
+      return isSuccess;
+    }
   }
 
   /**

--- a/frontend/components/chat/chatroom/ChatroomSidebar.tsx
+++ b/frontend/components/chat/chatroom/ChatroomSidebar.tsx
@@ -19,6 +19,7 @@ import Debug from 'debug';
 
 type Props = {
   socket: Socket;
+  currentRoom: CurrentRoom | undefined;
   setCurrentRoom: Dispatch<SetStateAction<CurrentRoom | undefined>>;
   setMessages: Dispatch<SetStateAction<Message[]>>;
   setError: Dispatch<SetStateAction<string>>;
@@ -26,6 +27,7 @@ type Props = {
 
 export const ChatroomSidebar = memo(function ChatroomSidebar({
   socket,
+  currentRoom,
   setCurrentRoom,
   setMessages,
   setError,
@@ -114,11 +116,14 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
     socket.on('chat:kicked', (chatroomId: number) => {
       debug('kicked from', chatroomId);
 
-      setError(`You are kicked`);
+      if (chatroomId === currentRoom?.id) {
+        setError(`You are kicked`);
+        setCurrentRoom(undefined);
+      }
+
       setRooms((prevRooms) =>
         prevRooms.filter((room) => room.id !== chatroomId),
       );
-      setCurrentRoom(undefined);
     });
 
     // setupが終わったら入室中のチャットルーム一覧を取得する
@@ -133,7 +138,15 @@ export const ChatroomSidebar = memo(function ChatroomSidebar({
       socket.off('chat:addPassword');
       socket.off('chat:kicked');
     };
-  }, [user, debug, setCurrentRoom, setMessages, socket, setError]);
+  }, [
+    user,
+    debug,
+    setCurrentRoom,
+    setMessages,
+    socket,
+    setError,
+    currentRoom?.id,
+  ]);
 
   const addRooms = (room: Chatroom) => {
     setRooms((prev) => [...prev, room]);

--- a/frontend/pages/chat/index.tsx
+++ b/frontend/pages/chat/index.tsx
@@ -100,6 +100,7 @@ const Chat: NextPage = () => {
         >
           <ChatroomSidebar
             socket={socket}
+            currentRoom={currentRoom}
             setCurrentRoom={setCurrentRoom}
             setMessages={setMessages}
             setError={setError}


### PR DESCRIPTION
## 概要

### Before

- Banされたユーザーに'You are banned.'のメッセージが表示されず、Banされた部屋からも退出させられていなかった
- KickされたユーザーはKickされた部屋に入っていない場合でも、'You are kicked.'のメッセージが表示され、その時点で入室していたチャットルームから強制退室させられてしまっていた

### After

- Ban/KickされたユーザーがBan/Kickされた部屋に入室中だった場合に限って、エラーメッセージを表示するとともに、入室中の部屋から強制退室させられるようにした

## Demo

### Ban

https://user-images.githubusercontent.com/15176241/218739687-7d6cead1-740d-49fe-bc2c-fe30460484bc.mov

### Kick

https://user-images.githubusercontent.com/15176241/218739778-942f5959-321c-46b9-9581-361e331cc790.mov
